### PR TITLE
Log duplicate entry when creating user

### DIFF
--- a/backend/interface/http/oauth.go
+++ b/backend/interface/http/oauth.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -237,6 +238,9 @@ func (s *OAuthServer) oauthGoogleCallback(w http.ResponseWriter, r *http.Request
 		}
 		u, _, err := s.userUsecase.CreateWithGoogle(ctx, name, email, googleID)
 		if err != nil {
+			if strings.Contains(err.Error(), "Error 1062: Duplicate entry") {
+				s.appLogger.Error("duplicate entry from CreateWithGoogle", zap.Error(err), zap.String("googleID", googleID))
+			}
 			internalServerError(r.Context(), s.errorRecorder, w, err, 0)
 			return
 		}


### PR DESCRIPTION
> errors.withStack: model2: unable to insert into user: Error 1062: Duplicate entry 'X' for key 'user.email' (Most recent call last)