### PR TITLE
Introduce new lesson fetcher

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
           name: "Setup database"
           command: |
             set -eu
+            mysql -uroot -h ${MYSQL_HOST} -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES'"
             mysql -uroot -h ${MYSQL_HOST} -e "CREATE USER IF NOT EXISTS 'lekcije'@'%' identified by 'lekcije'"
             mysql -uroot -h ${MYSQL_HOST} -e "CREATE DATABASE IF NOT EXISTS lekcije_test DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci"
             mysql -uroot -h ${MYSQL_HOST} -e "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, INDEX, ALTER, LOCK TABLES ON \`lekcije\\_test%\`.* TO 'lekcije'@'%'"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -73,8 +73,8 @@ jobs:
           fi
       - name: Create database
         run: |
+          mysql -h${MYSQL_HOST} -uroot -proot -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES'"
           mysql -h${MYSQL_HOST} -uroot -proot < ./db/docker-entrypoint-initdb.d/create_database.sql
-          mysql -h${MYSQL_HOST} -uroot -proot -e "SHOW VARIABLES LIKE 'sql_mode'"
       - name: Apply database migrations
         run: |
           export PATH=${PATH}:${GOPATH}/bin

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Create database
         run: |
           mysql -h${MYSQL_HOST} -uroot -proot < ./db/docker-entrypoint-initdb.d/create_database.sql
+          mysql -h${MYSQL_HOST} -uroot -proot -e "SHOW VARIABLES LIKE 'sql_mode'"
       - name: Apply database migrations
         run: |
           export PATH=${PATH}:${GOPATH}/bin

--- a/backend/cmd/notifier2/main.go
+++ b/backend/cmd/notifier2/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"os"
+
+	"github.com/oinume/lekcije/backend/cli"
+)
+
+func main() {
+	m := &notifierMain{
+		outStream: os.Stdout,
+		errStream: os.Stderr,
+	}
+	if err := m.run(os.Args); err != nil {
+		cli.WriteError(m.errStream, err)
+		os.Exit(cli.ExitError)
+	}
+	os.Exit(cli.ExitOK)
+}
+
+type notifierMain struct {
+	outStream io.Writer
+	errStream io.Writer
+}
+
+func (m *notifierMain) run(args []string) error {
+	flagSet := flag.NewFlagSet("notifier", flag.ContinueOnError)
+	flagSet.SetOutput(m.errStream)
+	var (
+		concurrency          = flagSet.Int("concurrency", 1, "Concurrency of fetcher")
+		dryRun               = flagSet.Bool("dry-run", false, "Don't update database with fetched lessons")
+		fetcherCache         = flagSet.Bool("fetcher-cache", false, "Cache teacher and lesson data in Fetcher")
+		notificationInterval = flagSet.Int("notification-interval", 0, "Notification interval")
+		sendEmail            = flagSet.Bool("send-email", true, "Flag to send email")
+		logLevel             = flagSet.String("log-level", "info", "Log level")
+	)
+	if err := flagSet.Parse(args[1:]); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/backend/cmd/notifier2/main.go
+++ b/backend/cmd/notifier2/main.go
@@ -89,8 +89,9 @@ func (m *notifierMain) run(args []string) error {
 	if err != nil {
 		return err
 	}
+	mCountryList := model2.NewMCountryList(mCountries)
 
-	lessonFetcher := dmm_eikaiwa.NewLessonFetcher(nil, *concurrentcy)
+	lessonFetcher := dmm_eikaiwa.NewLessonFetcher(nil, *concurrency, *fetcherCache, mCountryList, appLogger)
 	notificationUsecase := usecase.NewNotification()
 	notifier := notificationUsecase.NewLessonNotifier(lessonFetcher)
 	defer notifier.Close(ctx, &model2.StatNotifier{

--- a/backend/cmd/notifier2/main.go
+++ b/backend/cmd/notifier2/main.go
@@ -41,12 +41,12 @@ func (m *notifierMain) run(args []string) error {
 	flagSet := flag.NewFlagSet("notifier", flag.ContinueOnError)
 	flagSet.SetOutput(m.errStream)
 	var (
-		concurrency          = flagSet.Int("concurrency", 1, "Concurrency of fetcher")
-		dryRun               = flagSet.Bool("dry-run", false, "Don't update database with fetched lessons")
+		concurrency = flagSet.Int("concurrency", 1, "Concurrency of fetcher")
+		//		dryRun               = flagSet.Bool("dry-run", false, "Don't update database with fetched lessons")
 		fetcherCache         = flagSet.Bool("fetcher-cache", false, "Cache teacher and lesson data in Fetcher")
 		notificationInterval = flagSet.Int("notification-interval", 0, "Notification interval")
-		sendEmail            = flagSet.Bool("send-email", true, "Flag to send email")
-		logLevel             = flagSet.String("log-level", "info", "Log level")
+		//		sendEmail            = flagSet.Bool("send-email", true, "Flag to send email")
+		logLevel = flagSet.String("log-level", "info", "Log level")
 	)
 	if err := flagSet.Parse(args[1:]); err != nil {
 		return err
@@ -76,7 +76,7 @@ func (m *notifierMain) run(args []string) error {
 	defer func() { _ = gormDB.Close() }()
 
 	dbRepo := mysql.NewDBRepository(gormDB.DB())
-	lessonRepo := mysql.NewLessonRepository(gormDB.DB())
+	//	lessonRepo := mysql.NewLessonRepository(gormDB.DB())
 	userRepo := mysql.NewUserRepository(gormDB.DB())
 	userGoogleRepo := mysql.NewUserGoogleRepository(gormDB.DB())
 	userUsecase := usecase.NewUser(dbRepo, userRepo, userGoogleRepo)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -121,8 +121,9 @@ func startHTTPServer(port int, args *interfaces.ServerArgs) error {
 	server := interfaces_http.NewServer(args, errorRecorder, userAPIToken)
 	oauthServer := di.NewOAuthServer(args.AppLogger, args.DB, args.GAMeasurementClient, args.RollbarClient, args.SenderHTTPClient)
 	errorRecorderHooks := interfaces_http.NewErrorRecorderHooks(errorRecorder)
+	mCountryList := di.MustNewMCountryList(context.Background(), args.DB)
 	meServer := di.NewMeServer(
-		args.AppLogger, args.GormDB, errorRecorderHooks, args.GAMeasurementClient,
+		args.AppLogger, args.GormDB, errorRecorderHooks, args.GAMeasurementClient, mCountryList,
 	)
 	server.Setup(mux)
 	oauthServer.Setup(mux)

--- a/backend/cmd/teacher_error_resetter/main_test.go
+++ b/backend/cmd/teacher_error_resetter/main_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/oinume/lekcije/backend/domain/config"
-	"github.com/oinume/lekcije/backend/fetcher"
+	"github.com/oinume/lekcije/backend/internal/mock"
 	"github.com/oinume/lekcije/backend/model"
 )
 
@@ -60,7 +60,7 @@ func Test_teacherErrorResetterMain_run(t *testing.T) {
 				t.Fatalf("teacherService.CreateOrUpdate failed: err=%v", err)
 			}
 
-			mockTransport, err := fetcher.NewMockTransport("../../fetcher/testdata/3986.html") // TODO: path
+			mockTransport, err := mock.NewHTMLTransport("../../fetcher/testdata/3986.html") // TODO: path
 			if err != nil {
 				t.Fatalf("fetcher.NewMockTransport failed: err=%v", err)
 			}

--- a/backend/di/repository.go
+++ b/backend/di/repository.go
@@ -1,1 +1,17 @@
 package di
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/oinume/lekcije/backend/infrastructure/mysql"
+	"github.com/oinume/lekcije/backend/model2"
+)
+
+func MustNewMCountryList(ctx context.Context, db *sql.DB) *model2.MCountryList {
+	mCountries, err := mysql.NewMCountryRepository(db).FindAll(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return model2.NewMCountryList(mCountries)
+}

--- a/backend/di/server.go
+++ b/backend/di/server.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/oinume/lekcije/backend/infrastructure/ga_measurement"
 	ihttp "github.com/oinume/lekcije/backend/interface/http"
+	"github.com/oinume/lekcije/backend/model2"
 	api_v1 "github.com/oinume/lekcije/backend/proto_gen/proto/api/v1"
 )
 
@@ -37,10 +38,11 @@ func NewMeServer(
 	db *gorm.DB,
 	errorRecorderHooks *twirp.ServerHooks,
 	gaMeasurementClient ga_measurement.Client,
+	mCountryList *model2.MCountryList,
 ) api_v1.TwirpServer {
 	meService := ihttp.NewMeService(
 		db, appLogger,
-		NewFollowingTeacherUsecase(appLogger, db.DB()),
+		NewFollowingTeacherUsecase(appLogger, db.DB(), mCountryList),
 		NewGAMeasurementUsecase(gaMeasurementClient),
 		NewNotificationTimeSpanUsecase(db.DB()),
 		NewUserUsecase(db.DB()),

--- a/backend/di/usecase.go
+++ b/backend/di/usecase.go
@@ -6,9 +6,11 @@ import (
 	"github.com/rollbar/rollbar-go"
 	"go.uber.org/zap"
 
+	"github.com/oinume/lekcije/backend/infrastructure/dmm_eikaiwa"
 	iga_measurement "github.com/oinume/lekcije/backend/infrastructure/ga_measurement"
 	"github.com/oinume/lekcije/backend/infrastructure/mysql"
 	irollbar "github.com/oinume/lekcije/backend/infrastructure/rollbar"
+	"github.com/oinume/lekcije/backend/model2"
 	"github.com/oinume/lekcije/backend/usecase"
 )
 
@@ -19,14 +21,14 @@ func NewErrorRecorderUsecase(appLogger *zap.Logger, rollbarClient *rollbar.Clien
 	)
 }
 
-func NewFollowingTeacherUsecase(appLogger *zap.Logger, db *sql.DB) *usecase.FollowingTeacher {
+func NewFollowingTeacherUsecase(appLogger *zap.Logger, db *sql.DB, mCountryList *model2.MCountryList) *usecase.FollowingTeacher {
 	return usecase.NewFollowingTeacher(
 		appLogger,
 		mysql.NewDBRepository(db),
 		mysql.NewFollowingTeacherRepository(db),
-		mysql.NewMCountryRepository(db),
 		mysql.NewUserRepository(db),
 		mysql.NewTeacherRepository(db),
+		dmm_eikaiwa.NewLessonFetcher(nil, 1, false, mCountryList, appLogger),
 	)
 }
 

--- a/backend/domain/repository/lesson.go
+++ b/backend/domain/repository/lesson.go
@@ -1,0 +1,5 @@
+package repository
+
+type Lesson interface{}
+
+type LessonFetcher interface{}

--- a/backend/domain/repository/lesson.go
+++ b/backend/domain/repository/lesson.go
@@ -1,5 +1,13 @@
 package repository
 
+import (
+	"context"
+
+	"github.com/oinume/lekcije/backend/model2"
+)
+
 type Lesson interface{}
 
-type LessonFetcher interface{}
+type LessonFetcher interface {
+	Fetch(ctx context.Context, teacherID uint) (*model2.Teacher, []*model2.Lesson, error)
+}

--- a/backend/domain/repository/lesson.go
+++ b/backend/domain/repository/lesson.go
@@ -9,5 +9,6 @@ import (
 type Lesson interface{}
 
 type LessonFetcher interface {
+	Close()
 	Fetch(ctx context.Context, teacherID uint) (*model2.Teacher, []*model2.Lesson, error)
 }

--- a/backend/domain/repository/user.go
+++ b/backend/domain/repository/user.go
@@ -13,6 +13,7 @@ type User interface {
 	FindByEmailWithExec(ctx context.Context, exec Executor, email string) (*model2.User, error)
 	FindByGoogleID(ctx context.Context, googleID string) (*model2.User, error)
 	FindByGoogleIDWithExec(ctx context.Context, exec Executor, googleID string) (*model2.User, error)
+	FindAllByEmailVerified(ctx context.Context, notificationInterval int) ([]*model2.User, error)
 	UpdateEmail(ctx context.Context, id uint, email string) error
 	UpdateFollowedTeacherAt(ctx context.Context, id uint, time time.Time) error
 	UpdateOpenNotificationAt(ctx context.Context, id uint, time time.Time) error

--- a/backend/fetcher/fetcher.go
+++ b/backend/fetcher/fetcher.go
@@ -462,6 +462,7 @@ func MustInt(s string) int {
 	return int(i)
 }
 
+// TOOD: Remove
 type MockTransport struct {
 	sync.Mutex
 	NumCalled int

--- a/backend/fetcher/fetcher.go
+++ b/backend/fetcher/fetcher.go
@@ -462,49 +462,6 @@ func MustInt(s string) int {
 	return int(i)
 }
 
-// TOOD: Remove
-type MockTransport struct {
-	sync.Mutex
-	NumCalled int
-	content   string
-}
-
-// TODO: Move to fetcher_test
-func NewMockTransport(path string) (*MockTransport, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("os.Open failed: path=%v, err=%v", path, err)
-	}
-	b, err := ioutil.ReadAll(file)
-	if err != nil {
-		return nil, fmt.Errorf("read file failed: err=%v", err)
-	}
-	return &MockTransport{
-		content: string(b),
-	}, nil
-}
-
-func NewMockTransportFromHTML(content string) *MockTransport {
-	return &MockTransport{
-		content: content,
-	}
-}
-
-func (t *MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	t.Lock()
-	t.NumCalled++
-	t.Unlock()
-	resp := &http.Response{
-		Header:     make(http.Header),
-		Request:    req,
-		StatusCode: http.StatusOK,
-		Status:     "200 OK",
-	}
-	resp.Header.Set("Content-Type", "text/html; charset=UTF-8")
-	resp.Body = ioutil.NopCloser(strings.NewReader(t.content))
-	return resp, nil
-}
-
 func getDefaultHTTPClient() *http.Client {
 	if !config.DefaultVars.EnableFetcherHTTP2 {
 		return defaultHTTPClient

--- a/backend/fetcher/fetcher_test.go
+++ b/backend/fetcher/fetcher_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/oinume/lekcije/backend/domain/config"
 	"github.com/oinume/lekcije/backend/errors"
+	"github.com/oinume/lekcije/backend/internal/mock"
 	"github.com/oinume/lekcije/backend/model"
 )
 
@@ -162,7 +163,7 @@ func TestFetchInternalServerError(t *testing.T) {
 func TestFetchConcurrency(t *testing.T) {
 	a := assert.New(t)
 	r := require.New(t)
-	mockTransport, err := NewMockTransport("testdata/3986.html")
+	mockTransport, err := mock.NewHTMLTransport("testdata/3986.html")
 	r.NoError(err)
 	client := &http.Client{Transport: mockTransport}
 	fetcher := NewLessonFetcher(client, *concurrency, false, mCountries, nil)

--- a/backend/infrastructure/dmm_eikaiwa/lesson_fetcher.go
+++ b/backend/infrastructure/dmm_eikaiwa/lesson_fetcher.go
@@ -2,41 +2,447 @@ package dmm_eikaiwa
 
 import (
 	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
 	"net/http"
+	"net/http/httptrace"
+	"regexp"
+	"strconv"
+	"strings"
 	"sync"
+	"time"
 
+	"github.com/Songmu/retry"
+	"github.com/ericlagergren/decimal"
+	"github.com/volatiletech/sqlboiler/v4/types"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
+	"golang.org/x/text/width"
+	"gopkg.in/xmlpath.v2"
 
+	"github.com/oinume/lekcije/backend/domain/config"
 	"github.com/oinume/lekcije/backend/domain/repository"
+	"github.com/oinume/lekcije/backend/errors"
+	"github.com/oinume/lekcije/backend/model"
 	"github.com/oinume/lekcije/backend/model2"
 )
 
+const (
+	userAgent = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html"
+)
+
+var (
+	_                 = fmt.Print
+	defaultHTTPClient = &http.Client{
+		Timeout:       5 * time.Second,
+		CheckRedirect: redirectErrorFunc,
+		Transport: &http.Transport{
+			MaxIdleConns:        100,
+			MaxIdleConnsPerHost: 100,
+			Proxy:               http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 1200 * time.Second,
+			}).DialContext,
+			IdleConnTimeout:     1200 * time.Second,
+			TLSHandshakeTimeout: 10 * time.Second,
+			TLSClientConfig: &tls.Config{
+				ClientSessionCache: tls.NewLRUClientSessionCache(100),
+			},
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+	redirectErrorFunc = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	titleXPath      = xmlpath.MustCompile(`//title`)
+	attributesXPath = xmlpath.MustCompile(`//div[@class='confirm low']/dl`)
+	lessonXPath     = xmlpath.MustCompile(`//ul[@class='oneday']//li`)
+	classAttrXPath  = xmlpath.MustCompile(`@class`)
+)
+
+type teacherLessons struct {
+	teacher *model2.Teacher
+	lessons []*model2.Lesson
+}
+
 type lessonFetcher struct {
-	httpClient *http.Client
-	semaphore  chan struct{}
-	caching    bool
-	//	cache      map[uint32]*teacherLessons
-	cacheLock  *sync.RWMutex
-	logger     *zap.Logger
-	mCountries []*model2.MCountry
+	httpClient   *http.Client
+	semaphore    chan struct{}
+	caching      bool
+	cache        map[uint]*teacherLessons
+	cacheLock    *sync.RWMutex
+	logger       *zap.Logger
+	mCountryList *model2.MCountryList
 }
 
 func NewLessonFetcher(
 	httpClient *http.Client,
 	concurrency int,
 	caching bool,
-	mCountries []*model2.MCountry,
+	mCountryList *model2.MCountryList,
 	log *zap.Logger,
 ) repository.LessonFetcher {
 	return &lessonFetcher{
-		httpClient: httpClient,
-		caching:    caching,
-		mCountries: mCountries, // TODO: Define model2.MCountries
-		logger:     log,
+		httpClient:   httpClient,
+		semaphore:    make(chan struct{}, concurrency),
+		caching:      caching,
+		cache:        make(map[uint]*teacherLessons, 5000),
+		cacheLock:    new(sync.RWMutex),
+		mCountryList: mCountryList,
+		logger:       log,
 	}
 }
 
-func (f *lessonFetcher) Fetch(ctx context.Context, teacherID uint32) (*model2.Teacher, []*model2.Lesson, error) {
-	// TODO: Use otel for http client tracing
-	panic("implement")
+func (f *lessonFetcher) Fetch(ctx context.Context, teacherID uint) (*model2.Teacher, []*model2.Lesson, error) {
+	ctx, span := otel.Tracer(config.DefaultTracerName).Start(ctx, "LessonFetcher.Fetch")
+	span.SetAttributes(attribute.KeyValue{
+		Key:   "teacherID",
+		Value: attribute.Int64Value(int64(teacherID)),
+	})
+	defer span.End()
+
+	f.semaphore <- struct{}{}
+	defer func() {
+		<-f.semaphore
+	}()
+
+	// Check cache
+	if f.caching {
+		f.cacheLock.RLock()
+		if c, ok := f.cache[teacherID]; ok {
+			f.cacheLock.RUnlock()
+			return c.teacher, c.lessons, nil
+		}
+		f.cacheLock.RUnlock()
+	}
+
+	teacher := model2.NewTeacher(teacherID)
+	var content io.ReadCloser
+	err := retry.Retry(2, 300*time.Millisecond, func() error {
+		var err error
+		content, err = f.fetchContent(ctx, teacher.URL())
+		return err
+	})
+	defer content.Close()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	_, lessons, err := f.parseHTML(teacher, content)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(lessons) > 0 {
+		teacher.LastLessonAt = lessons[len(lessons)-1].Datetime
+	}
+	return teacher, lessons, nil
+}
+
+func (f *lessonFetcher) fetchContent(ctx context.Context, url string) (io.ReadCloser, error) {
+	clientTrace := otelhttptrace.NewClientTrace(ctx, otelhttptrace.WithoutSubSpans())
+	ctx = httptrace.WithClientTrace(ctx, clientTrace)
+	nopCloser := ioutil.NopCloser(strings.NewReader(""))
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nopCloser, errors.NewInternalError(
+			errors.WithError(err),
+			errors.WithMessagef("Failed to create HTTP request: url=%v", url),
+		)
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		return nopCloser, errors.NewInternalError(
+			errors.WithError(err),
+			errors.WithMessagef("Failed httpClient.Do(): url=%v", url),
+		)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return resp.Body, nil
+	case http.StatusMovedPermanently, http.StatusFound:
+		_ = resp.Body.Close()
+		return nopCloser, errors.NewNotFoundError(
+			errors.WithMessagef("Teacher not found: url=%v, statusCode=%v", url, resp.StatusCode),
+		)
+	default:
+		_ = resp.Body.Close()
+		return nopCloser, errors.NewInternalError(
+			errors.WithMessagef(
+				"Unknown error in fetchContent: url=%v, statusCode=%v, status=%v",
+				url, resp.StatusCode, resp.Status,
+			),
+		)
+	}
+}
+
+func (f *lessonFetcher) parseHTML(
+	teacher *model2.Teacher,
+	html io.Reader,
+) (*model2.Teacher, []*model2.Lesson, error) {
+	root, err := xmlpath.ParseHTML(html)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// teacher name
+	if title, ok := titleXPath.String(root); ok {
+		teacher.Name = strings.Trim(strings.Split(title, "-")[0], " ")
+	} else {
+		return nil, nil, errors.NewInternalError(
+			errors.WithMessagef("failed to fetch teacher's name: url=%v", teacher.URL()),
+		)
+	}
+
+	// Nationality, birthday, etc...
+	f.parseTeacherAttribute(teacher, root)
+	if !teacher.IsJapanese() { // Japanese teachers don't have favorite count
+		// FavoriteCount
+		f.parseTeacherFavoriteCount(teacher, root)
+	}
+	// Rating
+	f.parseTeacherRating(teacher, root)
+
+	dateRegexp := regexp.MustCompile(`([\d]+)月([\d]+)日(.+)`)
+	lessons := make([]*model2.Lesson, 0, 1000)
+	now := time.Now().In(config.LocalLocation())
+	originalDate := time.Now().In(config.LocalLocation()).Truncate(24 * time.Hour)
+	date := originalDate
+	// lessons
+	for iter := lessonXPath.Iter(root); iter.Next(); {
+		node := iter.Node()
+		timeClass, ok := classAttrXPath.String(node)
+		if !ok {
+			continue
+		}
+
+		text := strings.Trim(node.String(), " ")
+
+		//fmt.Printf("text = '%v', timeClass = '%v'\n", text, timeClass)
+		f.logger.Debug("Scraping as", zap.String("timeClass", timeClass), zap.String("text", text))
+
+		// blank, available, reserved
+		if timeClass == "date" {
+			group := dateRegexp.FindStringSubmatch(text)
+			if len(group) > 0 {
+				month, day := MustInt(group[1]), MustInt(group[2])
+				year := date.Year()
+				if now.Month() == time.December && month == 1 {
+					year = now.Year() + 1
+				}
+				originalDate = time.Date(
+					year, time.Month(month), int(day),
+					0, 0, 0, 0,
+					config.LocalLocation(),
+				)
+				date = originalDate
+			}
+		} else if strings.HasPrefix(timeClass, "t-") && text != "" {
+			tmp := strings.Split(timeClass, "-")
+			hour, minute := MustInt(tmp[1]), MustInt(tmp[2])
+			if hour >= 24 {
+				// Convert 24:30 -> 00:30
+				hour -= 24
+				if date.Unix() == originalDate.Unix() {
+					// Set date to next day for 24:30
+					date = date.Add(24 * time.Hour)
+				}
+			}
+			dt := time.Date(
+				date.Year(), date.Month(), date.Day(),
+				hour, minute, 0, 0,
+				config.LocalLocation(),
+			)
+			status := model.LessonStatuses.MustValueForAlias(text)
+			f.logger.Debug(
+				"lesson",
+				zap.String("dt", dt.Format("2006-01-02 15:04")),
+				zap.String("status", model.LessonStatuses.MustName(status)),
+			)
+			lessons = append(lessons, &model2.Lesson{
+				TeacherID: teacher.ID,
+				Datetime:  dt,
+				Status:    model.LessonStatuses.MustName(status),
+			})
+		}
+		// TODO: else
+	}
+
+	// Set teacher lesson data to cache
+	if f.caching {
+		f.cacheLock.Lock()
+		f.cache[teacher.ID] = &teacherLessons{teacher: teacher, lessons: lessons}
+		f.cacheLock.Unlock()
+	}
+
+	return teacher, lessons, nil
+}
+
+func (f *lessonFetcher) parseTeacherAttribute(teacher *model2.Teacher, rootNode *xmlpath.Node) {
+	nameXPath := xmlpath.MustCompile(`./dt`)
+	valueXPath := xmlpath.MustCompile(`./dd`)
+	for iter := attributesXPath.Iter(rootNode); iter.Next(); {
+		node := iter.Node()
+		name, ok := nameXPath.String(node)
+		if !ok {
+			f.logger.Error(
+				fmt.Sprintf("Failed to parse teacher value: name=%v", name),
+				zap.Uint("teacherID", uint(teacher.ID)),
+			)
+			continue
+		}
+		value, ok := valueXPath.String(node)
+		if !ok {
+			f.logger.Error(
+				fmt.Sprintf("Failed to parse teacher value: name=%v, value=%v", name, value),
+				zap.Uint("teacherID", uint(teacher.ID)),
+			)
+			continue
+		}
+		if err := f.setTeacherAttribute(teacher, strings.TrimSpace(name), strings.TrimSpace(value)); err != nil {
+			f.logger.Error(
+				fmt.Sprintf("Failed to setTeacherAttribute: name=%v, value=%v", name, value),
+				zap.Uint("teacherID", uint(teacher.ID)),
+			)
+		}
+		//fmt.Printf("name = %v, value = %v\n", strings.TrimSpace(name), strings.TrimSpace(value))
+	}
+	//fmt.Printf("teacher = %+v\n", teacher)
+}
+
+func (f *lessonFetcher) setTeacherAttribute(teacher *model2.Teacher, name string, value string) error {
+	switch name {
+	case "国籍":
+		c, found := f.mCountryList.GetByNameJA(value)
+		if !found {
+			return errors.NewNotFoundError(errors.WithMessage(fmt.Sprintf("No MCountries for %v", value)))
+		}
+		teacher.CountryID = int16(c.ID) // TODO: teacher.CountryID must be uint16
+	case "誕生日":
+		value = width.Narrow.String(value)
+		if strings.TrimSpace(value) == "" {
+			teacher.Birthday = time.Time{}
+		} else {
+			t, err := time.Parse("2006-01-02", value)
+			if err != nil {
+				return err
+			}
+			teacher.Birthday = t
+		}
+	case "性別":
+		switch value {
+		case "男性":
+			teacher.Gender = "male" // TODO: enum
+		case "女性":
+			teacher.Gender = "female"
+		default:
+			return errors.NewInternalError(
+				errors.WithMessagef("Unknown gender for %v", value),
+			)
+		}
+	case "経歴":
+		var yoe int
+		switch value {
+		case "1年未満":
+			yoe = 0
+		case "3年以上":
+			yoe = 4
+		default:
+			value = strings.Replace(value, "年", "", -1)
+			if v, err := strconv.ParseInt(width.Narrow.String(value), 10, 32); err == nil {
+				yoe = int(v)
+			} else {
+				return errors.NewInternalError(
+					errors.WithError(err),
+					errors.WithMessagef("Failed to convert to number: %v", value),
+				)
+			}
+		}
+		teacher.YearsOfExperience = int8(yoe) // TODO: teacher.YearsOfExperience must be uint8
+	}
+	return nil
+}
+
+func (f *lessonFetcher) parseTeacherFavoriteCount(teacher *model2.Teacher, rootNode *xmlpath.Node) {
+	favCountXPath := xmlpath.MustCompile(`//span[@id='fav_count']`)
+	value, ok := favCountXPath.String(rootNode)
+	if !ok {
+		f.logger.Error(
+			"Failed to parse teacher favorite count",
+			zap.Uint("teacherID", uint(teacher.ID)),
+		)
+		return
+	}
+	v, err := strconv.ParseUint(value, 10, 32)
+	if err != nil {
+		f.logger.Error(
+			"Failed to parse teacher favorite count. It's not a number",
+			zap.Uint("teacherID", uint(teacher.ID)),
+		)
+		return
+	}
+	teacher.FavoriteCount = uint(v)
+}
+
+func (f *lessonFetcher) parseTeacherRating(teacher *model2.Teacher, rootNode *xmlpath.Node) {
+	totalXPath := xmlpath.MustCompile(`//p[@id='total']`)
+	value, ok := totalXPath.String(rootNode)
+	if !ok {
+		newTeacherXPath := xmlpath.MustCompile(`//dl/dd/img[@class='new_teacher']`)
+		if _, ok := newTeacherXPath.String(rootNode); !ok {
+			f.logger.Error(
+				"Failed to parse teacher review count",
+				zap.Uint("teacherID", uint(teacher.ID)),
+			)
+		}
+		// Give up to obtain review count and rating
+		return
+	}
+	matches := regexp.MustCompile(`\((\d+)件\)`).FindStringSubmatch(value)
+	reviewCount, err := strconv.ParseUint(matches[1], 10, 32)
+	if err != nil {
+		f.logger.Error(
+			"Failed to parse teacher review count. It's not a number",
+			zap.Uint("teacherID", uint(teacher.ID)),
+			zap.String("value", value),
+		)
+		return
+	}
+	teacher.ReviewCount = uint(reviewCount)
+
+	numXPath := xmlpath.MustCompile(`//li[@id='num']`)
+	value, ok = numXPath.String(rootNode)
+	if !ok {
+		f.logger.Error(
+			"Failed to parse teacher rating",
+			zap.Uint("teacherID", uint(teacher.ID)),
+		)
+		return
+	}
+	rating, err := strconv.ParseFloat(value, 32) // TODO: parse as int ?
+	if err != nil {
+		f.logger.Error(
+			"Failed to parse teacher rating. It's not a number",
+			zap.Uint("teacherID", uint(teacher.ID)),
+		)
+		return
+	}
+
+	teacher.Rating = types.NullDecimal{Big: decimal.New(int64(rating*100), 2)}
+}
+
+func MustInt(s string) int {
+	i, err := strconv.ParseInt(s, 10, 32)
+	if err != nil {
+		panic(err)
+	}
+	return int(i)
 }

--- a/backend/infrastructure/dmm_eikaiwa/lesson_fetcher.go
+++ b/backend/infrastructure/dmm_eikaiwa/lesson_fetcher.go
@@ -88,6 +88,9 @@ func NewLessonFetcher(
 	mCountryList *model2.MCountryList,
 	log *zap.Logger,
 ) repository.LessonFetcher {
+	if httpClient == nil {
+		httpClient = defaultHTTPClient
+	}
 	return &lessonFetcher{
 		httpClient:   httpClient,
 		semaphore:    make(chan struct{}, concurrency),
@@ -436,6 +439,10 @@ func (f *lessonFetcher) parseTeacherRating(teacher *model2.Teacher, rootNode *xm
 	}
 
 	teacher.Rating = types.NullDecimal{Big: decimal.New(int64(rating*100), 2)}
+}
+
+func (f *lessonFetcher) Close() {
+	close(f.semaphore)
 }
 
 func MustInt(s string) int {

--- a/backend/infrastructure/dmm_eikaiwa/lesson_fetcher.go
+++ b/backend/infrastructure/dmm_eikaiwa/lesson_fetcher.go
@@ -225,7 +225,6 @@ func (f *lessonFetcher) parseHTML(
 		}
 
 		text := strings.Trim(node.String(), " ")
-
 		//fmt.Printf("text = '%v', timeClass = '%v'\n", text, timeClass)
 		f.logger.Debug("Scraping as", zap.String("timeClass", timeClass), zap.String("text", text))
 
@@ -261,7 +260,7 @@ func (f *lessonFetcher) parseHTML(
 				hour, minute, 0, 0,
 				config.LocalLocation(),
 			)
-			status := model.LessonStatuses.MustValueForAlias(text)
+			status := model2.LessonStatuses.MustValueForAlias(text)
 			f.logger.Debug(
 				"lesson",
 				zap.String("dt", dt.Format("2006-01-02 15:04")),
@@ -270,7 +269,7 @@ func (f *lessonFetcher) parseHTML(
 			lessons = append(lessons, &model2.Lesson{
 				TeacherID: teacher.ID,
 				Datetime:  dt,
-				Status:    model.LessonStatuses.MustName(status),
+				Status:    model2.LessonStatuses.MustName(status),
 			})
 		}
 		// TODO: else
@@ -295,7 +294,7 @@ func (f *lessonFetcher) parseTeacherAttribute(teacher *model2.Teacher, rootNode 
 		if !ok {
 			f.logger.Error(
 				fmt.Sprintf("Failed to parse teacher value: name=%v", name),
-				zap.Uint("teacherID", uint(teacher.ID)),
+				zap.Uint("teacherID", teacher.ID),
 			)
 			continue
 		}
@@ -303,14 +302,14 @@ func (f *lessonFetcher) parseTeacherAttribute(teacher *model2.Teacher, rootNode 
 		if !ok {
 			f.logger.Error(
 				fmt.Sprintf("Failed to parse teacher value: name=%v, value=%v", name, value),
-				zap.Uint("teacherID", uint(teacher.ID)),
+				zap.Uint("teacherID", teacher.ID),
 			)
 			continue
 		}
 		if err := f.setTeacherAttribute(teacher, strings.TrimSpace(name), strings.TrimSpace(value)); err != nil {
 			f.logger.Error(
 				fmt.Sprintf("Failed to setTeacherAttribute: name=%v, value=%v", name, value),
-				zap.Uint("teacherID", uint(teacher.ID)),
+				zap.Uint("teacherID", teacher.ID),
 			)
 		}
 		//fmt.Printf("name = %v, value = %v\n", strings.TrimSpace(name), strings.TrimSpace(value))

--- a/backend/infrastructure/dmm_eikaiwa/lesson_fetcher.go
+++ b/backend/infrastructure/dmm_eikaiwa/lesson_fetcher.go
@@ -1,0 +1,42 @@
+package dmm_eikaiwa
+
+import (
+	"context"
+	"net/http"
+	"sync"
+
+	"go.uber.org/zap"
+
+	"github.com/oinume/lekcije/backend/domain/repository"
+	"github.com/oinume/lekcije/backend/model2"
+)
+
+type lessonFetcher struct {
+	httpClient *http.Client
+	semaphore  chan struct{}
+	caching    bool
+	//	cache      map[uint32]*teacherLessons
+	cacheLock  *sync.RWMutex
+	logger     *zap.Logger
+	mCountries []*model2.MCountry
+}
+
+func NewLessonFetcher(
+	httpClient *http.Client,
+	concurrency int,
+	caching bool,
+	mCountries []*model2.MCountry,
+	log *zap.Logger,
+) repository.LessonFetcher {
+	return &lessonFetcher{
+		httpClient: httpClient,
+		caching:    caching,
+		mCountries: mCountries, // TODO: Define model2.MCountries
+		logger:     log,
+	}
+}
+
+func (f *lessonFetcher) Fetch(ctx context.Context, teacherID uint32) (*model2.Teacher, []*model2.Lesson, error) {
+	// TODO: Use otel for http client tracing
+	panic("implement")
+}

--- a/backend/infrastructure/dmm_eikaiwa/lesson_fetcher_test.go
+++ b/backend/infrastructure/dmm_eikaiwa/lesson_fetcher_test.go
@@ -1,0 +1,233 @@
+package dmm_eikaiwa
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/oinume/lekcije/backend/domain/config"
+	"github.com/oinume/lekcije/backend/errors"
+	"github.com/oinume/lekcije/backend/infrastructure/mysql"
+	"github.com/oinume/lekcije/backend/internal/assertion"
+	"github.com/oinume/lekcije/backend/model"
+	"github.com/oinume/lekcije/backend/model2"
+)
+
+var (
+	concurrency  = flag.Int("concurrency", 1, "concurrency")
+	mCountryList *model2.MCountryList
+)
+
+func TestMain(m *testing.M) {
+	config.MustProcessDefault()
+	testDBURL := model.ReplaceToTestDBURL(nil, config.DefaultVars.DBURL())
+	var err error
+	db, err := model.OpenDB(testDBURL, 1, config.DefaultVars.DebugSQL)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	mCountries, err := mysql.NewMCountryRepository(db.DB()).FindAll(ctx)
+	if err != nil {
+		panic(err)
+	}
+	mCountryList = model2.NewMCountryList(mCountries)
+
+	os.Exit(m.Run())
+}
+
+func Test_lessonFetcher_Fetch(t *testing.T) {
+	transport := &errorTransport{okThreshold: 0}
+	httpClient := &http.Client{Transport: transport}
+	fetcher := NewLessonFetcher(httpClient, *concurrency, false, mCountryList, zap.NewNop())
+	ctx := context.Background()
+	teacher, lessons, err := fetcher.Fetch(ctx, 3986)
+	if err != nil {
+		t.Fatalf("fetcher.Fetch failed: %v", err)
+	}
+
+	assertion.AssertEqual(t, "Hena", teacher.Name, "")
+	assertion.AssertEqual(t, 45, len(lessons), "")
+	assertion.AssertEqual(t, 1, transport.callCount, "")
+}
+
+func Test_lessonFetcher_Fetch_Retry(t *testing.T) {
+	transport := &errorTransport{okThreshold: 2}
+	client := &http.Client{Transport: transport}
+	fetcher := NewLessonFetcher(client, 1, false, mCountryList, zap.NewNop())
+	teacher, _, err := fetcher.Fetch(context.Background(), 3986)
+	if err != nil {
+		t.Fatalf("fetcher.Fetch failed: %v", err)
+	}
+
+	assertion.AssertEqual(t, "Hena", teacher.Name, "")
+	assertion.AssertEqual(t, 2, transport.callCount, "")
+}
+
+func Test_lessonFetcher_Fetch_Redirect(t *testing.T) {
+	client := &http.Client{
+		Transport:     &redirectTransport{},
+		CheckRedirect: redirectErrorFunc,
+	}
+	fetcher := NewLessonFetcher(client, 1, false, mCountryList, zap.NewNop())
+	_, _, err := fetcher.Fetch(context.Background(), 5982)
+	if err == nil {
+		t.Fatalf("err must not be nil")
+	}
+
+	assertion.AssertEqual(t, true, errors.IsNotFound(err), "")
+}
+
+func Test_lessonFetcher_Fetch_InternalServerError(t *testing.T) {
+	client := &http.Client{
+		Transport: &responseTransport{
+			statusCode: http.StatusInternalServerError,
+			content:    "Internal Server Error",
+		},
+	}
+	fetcher := NewLessonFetcher(client, 1, false, mCountryList, zap.NewNop())
+	_, _, err := fetcher.Fetch(context.Background(), 5982)
+	if err == nil {
+		t.Fatalf("err must not be nil")
+	}
+
+	wantTexts := []string{
+		"Unknown error in fetchContent",
+		"statusCode=500",
+	}
+	for _, want := range wantTexts {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("err %q doesn't contain text %q", err, want)
+		}
+	}
+}
+
+func Test_lessonFetcher_Fetch_Concurrency(t *testing.T) {
+	mockTransport, err := NewMockTransport("testdata/3986.html")
+	r.NoError(err)
+	client := &http.Client{Transport: mockTransport}
+	fetcher := NewLessonFetcher(client, *concurrency, false, mCountries, nil)
+
+	const n = 500
+	wg := &sync.WaitGroup{}
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(teacherID int) {
+			defer wg.Done()
+			_, _, err := fetcher.Fetch(context.Background(), uint32(teacherID))
+			if err != nil {
+				fmt.Printf("err = %v\n", err)
+				return
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	a.Equal(n, mockTransport.NumCalled)
+}
+
+func Test_lessonFetcher_parseHTML(t *testing.T) {
+	a := assert.New(t)
+	r := require.New(t)
+	fetcher := NewLessonFetcher(http.DefaultClient, 1, false, mCountryList, zap.NewNop()).(*lessonFetcher)
+	file, err := os.Open("testdata/3986.html")
+	r.NoError(err)
+	t.Cleanup(func() {
+		_ = file.Close()
+	})
+
+	teacher, lessons, err := fetcher.parseHTML(model2.NewTeacher(uint(3986)), file)
+	r.NoError(err)
+	a.Equal("Hena", teacher.Name)
+	a.Equal(uint16(70), teacher.CountryID) // Bosnia and Herzegovina
+	a.Equal("female", teacher.Gender)
+	a.Equal("1996-04-14", teacher.Birthday.Format("2006-01-02"))
+	a.Equal(uint32(1763), teacher.FavoriteCount)
+	a.Equal(uint32(1366), teacher.ReviewCount)
+	a.Equal(float32(4.9), teacher.Rating)
+
+	a.True(len(lessons) > 0)
+	for _, lesson := range lessons {
+		if lesson.Datetime.Format("2006-01-02 15:04") == "2018-03-01 18:00" {
+			a.Equal("Finished", lesson.Status)
+		}
+		if lesson.Datetime.Format("2006-01-02 15:04") == "2018-03-03 06:30" {
+			a.Equal("Available", lesson.Status)
+		}
+		if lesson.Datetime.Format("2006-01-02 15:04") == "2018-03-03 02:00" {
+			a.Equal("Reserved", lesson.Status)
+		}
+	}
+	//fmt.Printf("%v\n", spew.Sdump(lessons))
+}
+
+//<a href="#" class="bt-open" id="a:3:{s:8:&quot;launched&quot;;s:19:&quot;2016-07-01 16:30:00&quot;;s:10:&quot;teacher_id&quot;;s:4:&quot;5982&quot;;s:9:&quot;lesson_id&quot;;s:8:&quot;25880364&quot;;}">予約可</a>
+
+type errorTransport struct {
+	okThreshold int
+	callCount   int
+}
+
+func (t *errorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.callCount++
+	if t.callCount < t.okThreshold {
+		return nil, fmt.Errorf("Please retry.")
+	}
+
+	resp := &http.Response{
+		Header:     make(http.Header),
+		Request:    req,
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+	}
+	resp.Header.Set("Content-Type", "text/html; charset=UTF-8")
+
+	file, err := os.Open("testdata/3986.html")
+	if err != nil {
+		return nil, err
+	}
+	resp.Body = file // Close() will be called by client
+	return resp, nil
+}
+
+type redirectTransport struct{}
+
+func (t *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp := &http.Response{
+		Header:     make(http.Header),
+		Request:    req,
+		StatusCode: http.StatusFound,
+		Status:     "302 Found",
+		Body:       ioutil.NopCloser(strings.NewReader("")),
+	}
+	resp.Header.Set("Location", "https://twitter.com/")
+	return resp, nil
+}
+
+type responseTransport struct {
+	statusCode int
+	status     string
+	content    string
+}
+
+func (t *responseTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp := &http.Response{
+		Header:     make(http.Header),
+		Request:    req,
+		StatusCode: t.statusCode,
+		Status:     t.status,
+		Body:       ioutil.NopCloser(strings.NewReader(t.content)),
+	}
+	return resp, nil
+}

--- a/backend/infrastructure/dmm_eikaiwa/testdata/3986.html
+++ b/backend/infrastructure/dmm_eikaiwa/testdata/3986.html
@@ -1,0 +1,1100 @@
+
+<!doctype html>
+<html>
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# website: http://ogp.me/ns/website#">
+
+
+
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" /><link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57-precomposed.png">
+  <link rel="apple-touch-icon" sizes="60x60" href="/apple-touch-icon-60x60-precomposed.png">
+  <link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-72x72-precomposed.png">
+  <link rel="apple-touch-icon" sizes="76x76" href="/apple-touch-icon-76x76-precomposed.png">
+  <link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-144x144-precomposed.png">
+  <link rel="apple-touch-icon" sizes="120x120" href="/apple-touch-icon-120x120-precomposed.png">
+  <link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144x144-precomposed.png">
+  <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152-precomposed.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180-precomposed.png">
+  <link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57.png">
+  <link rel="apple-touch-icon" sizes="60x60" href="/apple-touch-icon-60x60.png">
+  <link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-72x72.png">
+  <link rel="apple-touch-icon" sizes="76x76" href="/apple-touch-icon-76x76.png">
+  <link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114x114.png">
+  <link rel="apple-touch-icon" sizes="120x120" href="/apple-touch-icon-120x120.png">
+  <link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144x144.png">
+  <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png">
+  <link rel="icon" type="image/png" href="/favicon.ico" sizes="32x32">
+  <link rel="icon" type="image/png" href="/favicon.ico" sizes="192x192">
+  <link rel="icon" type="image/png" href="/favicon.ico" sizes="96x96">
+  <link rel="icon" type="image/png" href="/favicon.ico" sizes="16x16">
+  <link rel="manifest" href="/manifest.json">
+  <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+  <meta name="msapplication-TileColor" content="#da532c">
+  <meta name="msapplication-TileImage" content="/mstile-144x144.png">
+  <meta name="theme-color" content="#ffffff"><title>Hena - 講師詳細 - オンライン英会話ならDMM英会話</title>
+  <meta name="Description" content="Henaのプロフィールやメッセージをご紹介♪評価コメント、レッスンのスケジュールなど、レッスンを受ける前に先生の事を詳しく知るならこのページ。気になる講師の詳細情報をチェック！">
+  <meta name="Keywords" content="Hena,詳細,スケジュール">
+  <meta property="fb:app_id" content="197934573681424">
+  <meta property="og:locale" content="ja_JP">
+  <meta property="og:site_name" content="eikaiwa.dmm.com">
+  <meta property="og:title" content="Hena - DMM英会話">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="http://eikaiwa.dmm.com//teacher/index/3986/">
+  <meta property="og:image" content="http://image.eikaiwa.dmm.com/teacher/4178/f1990.jpg">
+  <meta property="og:description" content="プログラミングを学んでいるヘナ先生です。英語講師としては、オンラインとオフライン合わせて2年の経験があります。先生にとって日本は楽しそうなバケーションスポットが一杯のきれいな国だそうです。いつか日本に旅行に行くことに憧れる先生に、日本のことをたくさん話してあげませんか？">
+  <meta property="fb:admins" content="473018329397095" />
+
+  <link rel="stylesheet" type="text/css" href="/css/font-awesome.min.css?1487929611"/>
+
+
+
+  <link rel="stylesheet" type="text/css" href="/css/eikaiwa.css?1519793335"/>
+  <link rel="stylesheet" type="text/css" href="/css/global_navigation.css?1487929611"/>
+  <link rel="stylesheet" type="text/css" href="/css/tips.css?1487929611"/>
+  <link rel="stylesheet" type="text/css" href="/css/jquery-ui.css?1487929611"/>
+  <link rel="stylesheet" type="text/css" href="/css/slider.css?1487929611"/>
+  <link rel="stylesheet" type="text/css" href="/css/owl.carousel.css?1487929611"/>
+  <link rel="stylesheet" type="text/css" href="/css/owl.theme.css?1487929611"/>
+  <link rel="stylesheet" type="text/css" href="/css/tips.css?1487929611"/>
+  <link rel="stylesheet" type="text/css" href="//www.dmm.com/css/base.css"/>
+  <link rel="stylesheet" type="text/css" href="/css/header.css?1505201042"/>
+
+  <script type="text/javascript" src="/js/modernizr.js?1487929613"></script>
+  <script type="text/javascript" src="/js/jquery.js?1487929613"></script>
+  <script type="text/javascript" src="/js/jquery-migrate-1.2.1.js?1487929613"></script>
+  <script type="text/javascript" src="/js/eikaiwa.js?1515390665"></script>
+  <script type="text/javascript" src="/js/evaluation.js?1487929613"></script>
+  <script type="text/javascript" src="/js/velocity.min.js?1487929613"></script>
+
+  <script type="text/javascript" src="/js/bjqs-1.3.min.js?1487929613"></script>
+  <script type="text/javascript" src="/js/rollover.js?1487929613"></script>
+  <script type="text/javascript" src="/js/header.js?1504852575"></script>
+</head>
+<body class="d-body-mg0" data-region="japan" data-member-id="IeHjwyITojtySj5f">
+<!--[if IE 7]><div id="d-ie7"><![endif]-->
+<!-- google analytics -->
+<script type="text/javascript" src="/js/ga_tracking.js?1487929613"></script><script>window.dataLayer = window.dataLayer || []; dataLayer.push({"dtm":{"viewLayout":"pc","userId":"YToyOntzOjI6Iml2IjtzOjg6IgoFBNIQwtXLIjtzOjU6InZhbHVlIjtzOjI0OiISSVwxDtQ2LVN7vZEvUP7Ps0ENtt-uKAwiO30","hashId":"3.9b793cab42ae0dccd152ad8199c9be5634dae66e7472ecaa463fc9a843303cf8","userStatus":"LoggedIn","isPreferential":0,"isForeign":0}}); </script>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-TJX8T2');</script><!--[if IE 7]><div class="d-hd-ie7"><![endif]--><!--[if IE 8]><div class="d-hd-ie8"><![endif]--><!--[if IE 9]><div class="d-hd-ie9"><![endif]--><div id="d-header" class="hd-deviceDefault"><!-- i3-tag -->
+  <input id="i3_opnd" name="i3_opnd" type="hidden" value="IeHjwyITojtySj5f">
+  <input id="i3_vwtp" name="i3_vwtp" type="hidden" value="pc">
+  <!-- /i3-tag -->
+  <script>
+    // i3 tracking code
+    !function(a,b,c,d,e,f,g,h,i,j,k){g="DMMi3Object",h=a[g],a[g]=e,h&&(a[e]=a[h]),
+      a[e]=a[e]||function(){i=arguments[arguments.length-1],"function"==typeof i&&setTimeout(
+        function(b,c){return function(){a[e].q.length>b&&c()}}(a[e].q.length,i),f),a[e].q.push(
+        arguments)},a[e].q=a[e].q||[],a[e].t=f,j=b.createElement(c),k=b.getElementsByTagName(c)[0],
+      j.async=1,j.src=d,j.charset="utf-8",k.parentNode.insertBefore(j,k),a[e].s=~~new Date
+    }(window,document,"script","//stat.i3.dmm.com/latest/js/dmm.tracking.min.js","i3",2000);
+    i3('init', 'i3_eu8qhl');
+    i3('create');
+    i3('send', 'view', 'page');
+  </script>
+  <noscript>
+    <div class="hd-jsOff">
+      <a href="http://help.dmm.com/-/detail/=/qid=10105/" class="hd-jsOff__inner">
+        <p>JavaScriptを有効にしてください</p>
+        <span class="hd-bt__config">設定方法はこちら</span>
+      </a>
+    </div>
+  </noscript>
+  <div id="top" class="hd-main">
+    <div class="hd-main__left">
+      <div class="hd-main__menu">
+
+        <div class="hd-main__menu__item hd-fn-floatnavi-target">
+          <span class="hd-nav hd-nav--service hd-fn-floatnavi-icon"><span class="hd-nav__txt">サービス</span></span>
+          <div class="hd-floatnavi hd-floatnavi--serviceCom hd-fn-floatnavi-box">
+            <span class="hd-nav hd-nav--service hd-fn-floatnavi-icon"><span class="hd-nav__txt">サービス</span></span>
+            <div class="hd-floatnavi__box">
+              <div class="hd-service hd-service--01">
+                <div class="hd-service__boxLink">
+                  <a href="https://www.dmm.com/" class="hd-service__boxLink__com">DMM.com トップへ</a>
+                </div>
+                <ul class="hd-listService">
+                  <li class="hd-listService__item d-translate">
+                    <a href="http://games.dmm.com/" class="hd-listService__link hd-ico hd-ico--netgame">DMM GAMES</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="http://dlsoft.dmm.com/" class="hd-listService__link hd-ico hd-ico--pcsoft">PCゲーム/ソフトウェア</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="http://fx.dmm.com/" class="hd-listService__link hd-ico hd-ico--fx">DMM FX</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="https://bitcoin.dmm.com/" class="hd-listService__link hd-ico hd-ico--bitcoin">DMM Bitcoin</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="https://banusy.dmm.com" class="hd-listService__link hd-ico hd-ico--banusy">DMM バヌーシー</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="http://eikaiwa.dmm.com/" class="hd-listService__link hd-ico hd-ico--eikaiwa">DMM 英会話</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="https://lounge.dmm.com/" class="hd-listService__link hd-ico hd-ico--lounge">DMM オンラインサロン</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="https://kouenirai.dmm.com" class="hd-listService__link hd-ico hd-ico--kouenirai">講演依頼</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="http://www.dmm.com/rental/" class="hd-listService__link hd-ico hd-ico--rental">DVD/CDレンタル</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="http://www.dmm.com/rental/iroiro/" class="hd-listService__link hd-ico hd-ico--iroiro">いろいろレンタル</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="http://www.dmm.com/mono/" class="hd-listService__link hd-ico hd-ico--mono">通販</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="https://scratch.dmm.com/" class="hd-listService__link hd-ico hd-ico--scratch">DMM スクラッチ</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="https://mvno.dmm.com/" class="hd-listService__link hd-ico hd-ico--mvno">DMM mobile 格安スマホ</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="https://hikari.dmm.com/" class="hd-listService__link hd-ico hd-ico--hikari">DMM光 ネット回線</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="https://okan.dmm.com" class="hd-listService__link hd-ico hd-ico--okan">DMM Okan 家事代行</a>
+                  </li>
+                </ul>
+              </div>
+              <div class="hd-service hd-service--02">
+                <ul class="hd-listService">
+                  <li class="hd-listService__item d-translate">
+                    <a href="http://www.dmm.com/digital/" class="hd-listService__link hd-ico hd-ico--digital">動画</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="http://www.dmm.com/monthly/prime/" class="hd-listService__link hd-ico hd-ico--prime">動画見放題ch</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="http://www.dmm.com/lod/" class="hd-listService__link hd-ico hd-ico--lod">AKB48グループ</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="https://make.dmm.com/" class="hd-listService__link hd-ico hd-ico--make">DMM.make</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="http://robots.dmm.com/" class="hd-listService__link hd-ico hd-ico--robots">DMM.make ROBOTS</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="https://book.dmm.com/" class="hd-listService__link hd-ico hd-ico--book">電子書籍</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="https://www.dmm.com/top/special/teller/" class="hd-listService__link hd-ico hd-ico--teller">DMM TELLER</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="https://livecommune.dmm.com" class="hd-listService__link hd-ico hd-ico--commune">生配信</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="https://pictures.dmm.com" class="hd-listService__link hd-ico hd-ico--pictures">DMM pictures アニメ</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="https://p-town.dmm.com/" class="hd-listService__link hd-ico hd-ico--ptown">パチンコ/パチスロ</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="http://chariloto.dmm.com/" class="hd-listService__link hd-ico hd-ico--chari">DMM 競輪</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="https://vr-theater.dmm.com/" class="hd-listService__link hd-ico hd-ico--theater">DMM VR THEATER</a>
+                  </li>
+                  <li class="hd-listService__item d-translate">
+                    <a href="https://energy.dmm.com" class="hd-listService__link hd-ico hd-ico--energy">DMM エナジー/太陽光発電</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+
+        <div class="hd-main__menu__item">
+          <a href="http://eikaiwa.dmm.com/" class="hd-logo">
+            <img src="http://p.dmm.com/p/common/header/logo/logo_com_eikaiwa.png" srcset="http://p.dmm.com/p/common/header/logo/logo_com_eikaiwa.png 1x, http://p.dmm.com/p/common/header/logo/logo_com_eikaiwa@2x.png 2x" alt="DMM英会話" height="28">
+          </a>
+        </div>
+
+
+      </div>
+    </div>
+
+    <div class="hd-main__right">
+
+
+      <ul class="hd-main__submenu">
+
+        <li class="hd-main__submenu__item">
+          <a href="http://help.dmm.com/" class="hd-nav hd-nav--help"><span class="hd-nav__txt">ヘルプ</span></a>
+        </li>
+
+        <li class="hd-main__submenu__item hd-fn-floatnavi-target js-pointbalance">
+          <span class="hd-nav hd-nav--point hd-fn-floatnavi-icon"><span class="hd-nav__txt">ポイント</span></span>
+          <div class="hd-floatnavi hd-floatnavi--point hd-fn-floatnavi-box">
+            <span class="hd-nav hd-nav--point hd-fn-floatnavi-icon"><span class="hd-nav__txt">ポイント</span></span>
+            <div class="hd-floatnavi__box">
+              <div class="hd-point" data-channel="eikaiwa">
+                <div class="hd-point__loading">読み込み中</div>
+                <div class="hd-point__loadContent">
+                  <dl class="hd-point__total">
+                    <dt class="hd-point__total__ttl hd-ico hd-ico--point">$title</dt>
+                    <dd class="hd-point__total__item"><span class="hd-point__total__point">$total_point</span><span class="hd-point__total__txt">pt</span></dd>
+                  </dl>
+                  <ul class="hd-pointList"></ul>
+                  <div class="hd-point__charge"><a href="javascript:void(0)" id="js-pointbalance-charge-button" class="hd-btn hd-btn--charge">ポイントをチャージする</a></div>
+                  <ul class="hd-links hd-links--arrow">
+                    <li class="hd-links__item"><a href="https://www.dmm.com/my/-/point/balance/" class="hd-links__link"><span class="hd-links__txt">ポイント情報を確認する</span></a></li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li class="hd-main__submenu__item hd-fn-floatnavi-target">
+          <span class="hd-nav hd-nav--basket hd-fn-floatnavi-icon"><span class="hd-nav__txt">バスケット</span></span>
+          <div class="hd-floatnavi hd-floatnavi--basket hd-fn-floatnavi-box">
+            <a href="https://www.dmm.com/top/basket/basket_html/=/ch_navi=none/" class="hd-nav hd-nav--basket hd-fn-floatnavi-icon"><span class="hd-nav__txt">バスケット</span></a>
+            <div class="hd-floatnavi__box">
+              <div class="hd-basket hd-basket--01">
+                <dl class="hd-defList">
+                  <dt class="hd-defList__ttl hd-ico hd-ico--digital">デジタル商品</dt>
+                  <dd class="hd-defList__box">
+                    <ul class="hd-links hd-links--arrow">
+                      <li class="hd-links__item">
+                        <a href="http://www.dmm.com/digital/-/basket/" class="hd-links__link"><span class="hd-links__txt">動画</span></a>
+                      </li>
+                      <li class="hd-links__item">
+                        <a href="http://book.dmm.com/basket/" class="hd-links__link"><span class="hd-links__txt">電子書籍</span></a>
+                      </li>
+                      <li class="hd-links__item">
+                        <a href="http://dlsoft.dmm.com/basket/" class="hd-links__link"><span class="hd-links__txt">PCゲーム/ソフトウェア</span></a>
+                      </li>
+                    </ul>
+                  </dd>
+                </dl>
+                <dl class="hd-defList">
+                  <dt class="hd-defList__ttl hd-ico hd-ico--mono">通販</dt>
+                  <dd class="hd-defList__box">
+                    <ul class="hd-links hd-links--arrow">
+                      <li class="hd-links__item">
+                        <a href="http://www.dmm.com/mono/-/basket/" class="hd-links__link"><span class="hd-links__txt">通販</span></a>
+                      </li>
+                      <li class="hd-links__item">
+                        <a href="http://www.dmm.com/mono/dmp/-/basket/" class="hd-links__link"><span class="hd-links__txt">マーケットプレイス</span></a>
+                      </li>
+                    </ul>
+                  </dd>
+                </dl>
+              </div>
+              <div class="hd-basket hd-basket--02">
+                <dl class="hd-defList">
+                  <dt class="hd-defList__ttl hd-ico hd-ico--rental">レンタル</dt>
+                  <dd class="hd-defList__box">
+                    <ul class="hd-links hd-links--arrow">
+                      <li class="hd-links__item">
+                        <a href="http://www.dmm.com/rental/ppr/-/basket/" class="hd-links__link"><span class="hd-links__txt">DVD/CD</span></a>
+                      </li>
+                      <li class="hd-links__item">
+                        <a href="http://www.dmm.com/rental/comic/-/basket/" class="hd-links__link"><span class="hd-links__txt">コミック</span></a>
+                      </li>
+                      <li class="hd-links__item">
+                        <a href="http://www.dmm.com/rental/iroiro/-/basket/" class="hd-links__link"><span class="hd-links__txt">いろいろレンタル</span></a>
+                      </li>
+                    </ul>
+                  </dd>
+                </dl>
+                <dl class="hd-defList">
+                  <dt class="hd-defList__ttl hd-ico hd-ico--make">.make</dt>
+                  <dd class="hd-defList__box">
+                    <ul class="hd-links hd-links--arrow">
+                      <li class="hd-links__item">
+                        <a href="http://make.dmm.com/cart/" class="hd-links__link"><span class="hd-links__txt">3Dプリント</span></a>
+                      </li>
+                      <li class="hd-links__item">
+                        <a href="http://robots.dmm.com/basket" class="hd-links__link"><span class="hd-links__txt">ロボット</span></a>
+                      </li>
+                    </ul>
+                  </dd>
+                </dl>
+              </div>
+            </div>
+          </div>
+        </li>
+        <script charset="UTF-8" type="text/javascript" src="http://www.dmm.com/js/common/set_tracking.js"></script>
+        <li class="hd-main__submenu__item hd-fn-floatnavi-target d-translate">
+          <span class="hd-nav hd-nav--mypage hd-fn-floatnavi-icon"><span class="hd-nav__txt">マイページ</span></span>
+          <div class="hd-floatnavi hd-floatnavi--mypage hd-fn-floatnavi-box">
+            <span class="hd-nav hd-nav--mypage hd-fn-floatnavi-icon"><span class="hd-nav__txt">マイページ</span></span>
+            <div class="hd-floatnavi__box">
+              <div class="hd-my">
+                <div class="hd-my__logout">
+                  <a href="https://www.dmm.com/my/-/login/logout/=/type=gbutton/path=DRVESVwZTldRDlBRRFdIUwwIGFVfVEtNBwNUDlcXGFkLBVVBSQVYCg5K" class="hd-link hd-link--loout">ログアウト</a>
+                </div>
+                <div class="hd-my__box hd-my__box--01">
+                  <dl class="hd-defList">
+                    <dt class="hd-defList__ttl hd-ico hd-ico--purchased">購入済み情報</dt>
+                    <dd class="hd-defList__box">
+                      <ul class="hd-links">
+                        <li class="hd-links__item">
+                          <a href="http://www.dmm.com/digital/-/mylibrary/=/page=1/" class="hd-links__link" id="click_digital"><span class="hd-links__txt">動画</span><span class="hd-links__tag">購入済み商品</span></a>
+                        </li>
+                        <li class="hd-links__item">
+                          <a href="http://book.dmm.com/library/" class="hd-links__link" id="click_book"><span class="hd-links__txt">電子書籍</span><span class="hd-links__tag">購入済み商品</span></a>
+                        </li>
+                        <li class="hd-links__item">
+                          <a href="http://dlsoft.dmm.com/mylibrary/" class="hd-links__link" id="click_dlsoft"><span class="hd-links__txt">PCゲーム/ソフト</span><span class="hd-links__tag">購入済み商品</span></a>
+                        </li>
+                        <li class="hd-links__item">
+                          <a href="http://www.dmm.com/rental/-/wishlist/" class="hd-links__link" id="click_rental"><span class="hd-links__txt">月額レンタル</span><span class="hd-links__tag">月額リスト</span></a>
+                        </li>
+                        <li class="hd-links__item">
+                          <a href="https://www.dmm.com/rental/iroiro/-/order_list/" class="hd-links__link" id="click_iroiro"><span class="hd-links__txt">いろいろレンタル</span><span class="hd-links__tag">ご注文リスト</span></a>
+                        </li>
+                        <li class="hd-links__item">
+                          <a href="http://personal.games.dmm.com/my-games/" class="hd-links__link" id="click_netgame"><span class="hd-links__txt">DMM GAMES</span><span class="hd-links__tag">マイゲーム</span></a>
+                        </li>
+                        <li class="hd-links__item">
+                          <a href="http://www.dmm.com/mono/-/order/" class="hd-links__link" id="click_mono"><span class="hd-links__txt">通販</span><span class="hd-links__tag">注文履歴</span></a>
+                        </li>
+                      </ul>
+                      <ul class="hd-links">
+                        <li class="hd-links__item">
+                          <a href="http://www.dmm.com/auction/-/situation/" class="hd-links__link" id="click_auction"><span class="hd-links__txt">オークション</span><span class="hd-links__tag">オークション履歴</span></a>
+                        </li>
+                        <li class="hd-links__item">
+                          <a href="https://mvno.dmm.com/mypage/" class="hd-links__link" id="click_mvno"><span class="hd-links__txt">モバイル/格安スマホ</span><span class="hd-links__tag">マイページ</span></a>
+                        </li>
+                        <li class="hd-links__item">
+                          <a href="https://hikari.dmm.com/mypage/" class="hd-links__link" id="click_hikari"><span class="hd-links__txt">DMM光 ネット回線</span><span class="hd-links__tag">マイページ</span></a>
+                        </li>
+                        <li class="hd-links__item">
+                          <a href="https://make.dmm.com/mypage/my3d/" class="hd-links__link" id="click_make"><span class="hd-links__txt">make 3Dプリント</span><span class="hd-links__tag">マイ3Dデータ</span></a>
+                        </li>
+                        <li class="hd-links__item">
+                          <a href="https://robots.dmm.com/mypage/order" class="hd-links__link" id="click_robots"><span class="hd-links__txt">ロボット</span><span class="hd-links__tag">マイページ</span></a>
+                        </li>
+                        <li class="hd-links__item">
+                          <a href="http://lounge.dmm.com/mylounge/" class="hd-links__link" id="click_lounge"><span class="hd-links__txt">オンラインサロン</span><span class="hd-links__tag">入会中サロン</span></a>
+                        </li>
+                      </ul>
+                    </dd>
+                  </dl>
+                </div>
+                <div class="hd-my__box hd-my__box--02">
+                  <dl class="hd-defList">
+                    <dt class="hd-defList__ttl hd-ico hd-ico--account">アカウント</dt>
+                    <dd class="hd-defList__box">
+                      <ul class="hd-links hd-links--arrow">
+                        <li class="hd-links__item">
+                          <a href="http://www.dmm.com/my/-/top/" class="hd-links__link"><span class="hd-links__txt">お客様情報</span></a>
+                        </li>
+                      </ul>
+                    </dd>
+                  </dl>
+                  <dl class="hd-defList">
+                    <dt class="hd-defList__ttl hd-ico hd-ico--favorite">お気に入り</dt>
+                    <dd class="hd-defList__box">
+                      <ul class="hd-links hd-links--arrow">
+                        <li class="hd-links__item">
+                          <a href="http://www.dmm.com/digital/-/bookmark/" class="hd-links__link"><span class="hd-links__txt">動画</span></a>
+                        </li>
+                        <li class="hd-links__item">
+                          <a href="http://book.dmm.com/bookmark/" class="hd-links__link"><span class="hd-links__txt">電子書籍</span></a>
+                        </li>
+                        <li class="hd-links__item">
+                          <a href="http://dlsoft.dmm.com/bookmark/" class="hd-links__link"><span class="hd-links__txt">PCゲーム/ソフト</span></a>
+                        </li>
+                        <li class="hd-links__item">
+                          <a href="http://www.dmm.com/rental/-/bookmark/" class="hd-links__link"><span class="hd-links__txt">DVD/CDレンタル</span></a>
+                        </li>
+                        <li class="hd-links__item">
+                          <a href="http://www.dmm.com/mono/-/bookmark/" class="hd-links__link"><span class="hd-links__txt">通販</span></a>
+                        </li>
+                      </ul>
+                    </dd>
+                  </dl>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+
+
+      </ul>
+    </div>
+
+  </div>
+  <script type="text/javascript" src="http://www.dmm.com/js/bugfix.js?1421734015"></script>
+  <script type="text/javascript" src="http://www.dmm.com/js/head_parts_logo.js?1493014832"></script>
+  <script charset="UTF-8" type="text/javascript" src="http://www.dmm.com/js/common/pointbalance.js"></script>
+</div><!--[if gte IE 7]></div><![endif]--><div id="w"><div class="global-header is-tollPlanHeader">
+  <ul class="global-navi">
+    <!-- member start -->
+    <li><a href="/">トップ</a></li>
+    <li><a href="/list/" id="e_layouts_default_a_list">予約・講師検索</a></li>
+    <li><a href="/favorite/">お気に入り講師</a></li>
+    <li><a href="/material/">教材</a></li>
+    <li><a href="https://app.eikaiwa.dmm.com/daily-news">Daily News</a></li>
+    <!-- member end -->
+  </ul>
+  <ul class="user-navi">
+    <li class="ico fn-hover sub-navi-area">
+      <a href="/uknow/" class="item"><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/headernavi/uknow.png" alt="U Know Icon"></a>
+      <ul class="sub-navi fn-sub-navi">
+        <li class="head"><a href="/uknow/">英語の質問に専門家が回答！<br><span class="capt mt4">なんてuKnow?</span></a></li>
+        <li><a href="/uknow/">ホーム</a></li>
+        <li><a href="/uknow/new_answer/">新着回答</a></li>
+        <li><a href="/uknow/self/">投稿した質問</a></li>
+        <li><a href="/uknow/favorite/">役に立った</a></li>
+      </ul>
+    </li>
+
+    <li class="ico fn-hover sub-navi-area">
+      <a href="http://iknow.jp" class="item"><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/headernavi/iknow.png" alt="I Know Icon"></a>
+      <ul class="sub-navi fn-sub-navi">
+        <li class="head"><a href="http://iknow.jp">単語学習なら<br><span class="capt mt4">iKnow！</span></a></li>
+        <li><a href="http://iknow.jp">ホーム</a></li>
+        <li><a href="http://iknow.jp/content">コース</a></li>
+        <li><a href="http://iknow.jp/dictionary">iKnow! 辞書</a></li>
+      </ul>
+    </li>
+    <li class="ico fn-hover sub-navi-area">
+      <a href="https://eikaiwa.dmm.com/ryugaku/" class="item"><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/headernavi/ryugaku.png" alt="Ryugaku Icon"></a>
+      <ul class="sub-navi fn-sub-navi">
+        <li class="head"><a href="https://eikaiwa.dmm.com/ryugaku/">留学を身近に、1週間から。<span class="capt mt4">DMM留学</span></a></li>
+        <li><a href="https://eikaiwa.dmm.com/ryugaku/">ホーム</a></li>
+        <li><a href="https://eikaiwa.dmm.com/ryugaku//school/search/">学校検索</a></li>
+      </ul>
+    </li>
+    <!-- account navi start -->
+    <li class="account fn-hover sub-navi-area">
+      <div class="item">
+        <img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/headernavi/account.png" alt="Account Icon">
+        【メルカリ】        <span class="name">Kazuhiro</span>
+      </div>
+      <ul class="sub-navi fn-sub-navi">
+        <li class="head">
+          <span class="capt mb4">ご利用中のプラン</span><br>
+          スタンダードプラン / 毎日1レッスン                        <a href="/plan/" class="change">変更</a>
+        </li>
+        <li class="head ticket">
+          <p class="mb5">チケット</p>
+          <div class="fn-tg-area tg-area">
+            <p class="flex-space-between mb5">
+              <span class="pluslesson">プラスレッスン</span>
+              <span>
+                        <a href="/tickets/" class="link mr5">購入</a>                        <span class="fn-tg-button link">
+                            <span class="mr3">1</span>枚
+                        </span>
+                    </span>
+            </p>
+          </div>
+          <div class="fn-tg-box tg-box">
+            <ul class="small-navi">
+              <li class="flex-space-between">
+                <span>2018 / 03 / 24</span>
+                <span>
+                                <span class="mr3">
+                                    1                                </span>枚
+                            </span>
+              </li>
+            </ul>
+          </div>
+
+          <div class="fn-tg-area tg-area">
+            <p class="flex-space-between mb10">
+              <span class="plusnative">プラスネイティブ</span>
+              <span class="">
+                        <span class="mr3">0</span>枚
+                    </span>
+            </p>
+          </div>
+
+        </li>
+
+        <li><a href="/profile/">登録情報変更</a></li>
+        <li><a href="/certificate/">各種証明書の発行</a></li>
+        <li><a href="http://help.dmm.com/-/list/=/mid=291/" target="_blank">よくある質問</a></li>
+        <li><a href="/contact/">お問い合わせ</a></li>
+        <li><a href="/announce/">お知らせ</a></li>
+        <li><a href="https://www.dmm.com/my/-/login/logout/=/type=gbutton/path=DRVESVwZTldRDlBRRFdIUwwIGFVfVEs">ログアウト</a></li>
+      </ul>
+    </li>
+
+    <!-- account navi end -->
+  </ul>
+</div>
+  <div id="bg" style=""><div id="su">
+    <script type="text/javascript" src="/js/tooltip.js?1487929613"></script>
+    <script type="text/javascript" src="/js/popover.js?1487929613"></script>
+    <script type="text/javascript" src="//www.dmm.com/js/detail.js"></script>
+
+    <div id="side-navi">
+
+      <div class="side-info">
+        <p class="name">
+          <span>【メルカリ】</span><br />
+          <span>Kazuhiro</span>さま
+        </p>
+
+        <p class="total platinum"><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/sidenavi/tx_total.png" alt="英会話時間合計"><br>
+          <span>9975</span><br><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/sidenavi/tx_minute.png" alt="分"></p>
+
+        <p><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/sidenavi/ico_platinum.png" alt="ビジター"></p>
+        <p class="levelup"><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/sidenavi/tx_levelup.png" alt="レベルアップまで"><br>あと<span>25</span>分</p>
+
+        <div class="side-current-course">
+          <dl>
+            <dt>現在ご利用中のプラン</dt>
+            <dd class="standard_plan">スタンダードプラン<br>毎日1レッスン</dd>                </dl>
+
+          <ul class="count">
+            <li>
+              <dl>
+                <dt><span>本日受講済</span><em>0</em></dt>
+                <dd>レッスン</dd>
+              </dl>
+            </li>
+            <li>
+              <dl>
+                <dt><span>現在予約済</span><em>1</em></dt>
+                <dd>レッスン</dd>
+              </dl>
+            </li>
+            <li>
+              <dl>
+                <dt><span>現在予約可</span><em>0</em></dt>
+                <dd>レッスン</dd>
+              </dl>
+            </li>
+          </ul>
+
+        </div><!-- /side-current-couse -->
+
+        <div class="side-current-course">
+          <dl>
+            <dt class="side-pluslesson">プラスレッスンチケット</dt>
+          </dl>
+          <div class="plus-ticket-wrap">
+            <div class="plus-ticket-number float-l">
+              <img src="//image.eikaiwa.dmm.com/assets/p/general/eikaiwa/sidenavi/ico_ticket_small.png" alt=""><span>1</span>枚
+            </div>
+            <div class="plus-ticket-expiration float-r">
+              <p class="ticket-expiration">有効期限<small class="icon-circle question">?</small></p>
+            </div>
+            <br clear="all">
+            <div class="plus-ticket-buy">
+              <a href="/tickets/">チケットを購入する</a>
+            </div>
+          </div>
+        </div>
+
+
+        <!-- /side-current-couse -->
+
+      </div><!-- /side-info -->
+
+      <div class="side-base">
+        <ul class="sb-main">
+          <li><a href="http://eikaiwa.dmm.com/">英会話トップ</a></li>
+          <li><a href="http://eikaiwa.dmm.com/list/" id="e_elements_member_left_navi_a_list">予約・講師検索</a></li>
+          <li><a href="http://eikaiwa.dmm.com/favorite/" id="e_elements_member_left_navi_a_favorite">お気に入り講師一覧</a></li>
+          <li><a href="http://eikaiwa.dmm.com/book/book_list/" id="e_elements_member_left_navi_a_book_list">予約しているレッスン</a></li>
+          <li><a href="http://eikaiwa.dmm.com/lesson/" id="e_elements_member_left_navi_a_lesson_history">レッスン履歴</a></li>
+          <li><a href="http://eikaiwa.dmm.com/lesson/note/30981131">レッスンノート</a></li>
+          <li><a href="http://eikaiwa.dmm.com/material/" id="e_elements_member_left_navi_a_materials">レッスン教材</a></li>
+          <li><a href="http://eikaiwa.dmm.com/word_note/">単語一覧</a></li>
+          <li><a href="http://eikaiwa.dmm.com/achievements/">メダルコレクション</a></li>
+          <li><a href="https://eikaiwa.dmm.com/profile/">登録情報変更</a></li>
+
+          <li><a href="/certificate/">各種証明書の発行</a></li>
+          <li><a href="https://eikaiwa.dmm.com/contact/">お問い合わせ</a></li>
+        </ul>
+      </div><!-- /side-base -->
+
+      <div class="side-list">
+        <ul class="sb-main">
+          <li><a href="http://eikaiwa.dmm.com/guide/">初めての方へ</a></li>
+          <li><a href="http://eikaiwa.dmm.com/guide/about_teacher/">講師について</a></li>
+          <li><a href="http://eikaiwa.dmm.com/guide/lesson_top/">レッスンまでの流れ</a></li>
+          <li><a href="http://eikaiwa.dmm.com/guide/skype/">Skypeについて</a></li>
+          <li><a href="http://eikaiwa.dmm.com/guide/advantage/">DMM英会話5つの強み</a></li>
+          <li><a href="http://eikaiwa.dmm.com/monitor/">モニター体験レポート</a></li>
+          <li><a href="http://help.dmm.com/-/list/=/mid=291/">よくある質問</a></li>
+          <li><a href="/kids/">こども英会話</a></li>
+          <li><a href="/biz/">法人向けプラン </a></li>
+        </ul>
+      </div><!-- /side-base -->
+
+
+      <div class="side-skype">
+        <p>
+          <b>DMM英会話<br>緊急時チャットサポート</b>
+          <br>レッスン時のトラブル等Skypeチャットにて対応
+          <br>対応時間:朝9時〜深夜1時
+        </p>
+        <!-- Skype 'ログイン状態' button http://www.skype.com/go/skypebuttons -->
+        <a href="skype:dmmeikaiwa?chat">
+          <img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/sidenavi/bt_skype_online.png" alt="ログイン状態" />
+        </a>
+        <div class="box-inquiry">
+          <p>その他のお問い合わせは<br><a href="https://eikaiwa.dmm.com/contact/">こちらから</a></p>
+        </div>
+      </div>
+      <div class="mg-b10">
+        <a href="/guide/phrase/" onClick="return openViewCustom(this.href, 800, 800,'_phrase');"><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/sidenavi/bnr_phrase_sd.jpg" alt="よく使う！とっさのフレーズ帳" class="h_penetrate"></a>
+      </div>
+      <div class="mg-b10">
+        <a href="/blog/" target="_blank"><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/sidenavi/bnr_eigodmm_sd.jpg" alt="DMM英会話ブログ" class="h_penetrate"></a>
+      </div>
+      <div class="mg-b10">
+        <a href="/uknow/"><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/sidenavi/bnr_uknow_sd.jpg" alt="DMM英会話なんてuKnow?" class="h_penetrate"></a>
+      </div>
+    </div><!-- /side-navi -->
+    <div style='display: none;'>
+      <h3 class="ticket-title"><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/sidenavi/ico_ticket_big.png" alt="">チケットの有効期限</h3>
+      <div id="ticket-list">
+        <ul>
+          <li class=>2018 / 03 / 24<span><em>1</em>枚</span></li>        </ul>
+        <div class="ticket-buy"><a href="https://www.dmm.com/my/-/history/" target="_blank">チケットの購入履歴を確認</a></div>
+      </div>
+    </div>
+
+    <div style='display: none;'>
+      <h3 class="ticket-title-native"><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/sidenavi/ico_ticket_native_big.png" alt="">チケットの有効期限</h3>
+      <div id="ticket-list-native">
+        <ul class="ticket-list-color-native">
+        </ul>
+      </div>
+    </div>
+
+    <script>
+      // popover list of tickets
+      $('.ticket-expiration').popover({
+        html: true,
+        animation: false,
+        trigger: 'manual',
+        template: '<div class="popover popover-ticket"><div class="arrow"></div><div class="popover-inner"><h3 class="popover-title"></h3><div class="popover-content"><p></p></div></div></div>',
+        placement: 'right',
+        content: function() {
+          return $('#ticket-list').html();
+        },
+        title: function() {
+          return $('.ticket-title').html();
+        }
+      }).on("mouseenter", function() {
+        var _this = this;
+        $(this).popover("show");
+        $(this).siblings(".popover").on("mouseleave", function() {
+          $(_this).popover('hide');
+        });
+      }).on("mouseleave", function() {
+        var _this = this;
+        setTimeout(function() {
+          if (!$(".popover:hover").length) {
+            $(_this).popover("hide")
+          }
+        }, 100);
+      });
+
+      // popover list of tickets for native
+      $('.ticket-expiration-native').popover({
+        html: true,
+        animation: false,
+        trigger: 'manual',
+        template: '<div class="popover popover-ticket"><div class="arrow"></div><div class="popover-inner"><h3 class="popover-title"></h3><div class="popover-content"><p></p></div></div></div>',
+        placement: 'right',
+        content: function() {
+          return $('#ticket-list-native').html();
+        },
+        title: function() {
+          return $('.ticket-title-native').html();
+        }
+      }).on("mouseenter", function() {
+        var _this = this;
+        $(this).popover("show");
+        $(this).siblings(".popover").on("mouseleave", function() {
+          $(_this).popover('hide');
+        });
+      }).on("mouseleave", function() {
+        var _this = this;
+        setTimeout(function() {
+          if (!$(".popover:hover").length) {
+            $(_this).popover("hide")
+          }
+        }, 100);
+      });
+    </script>
+  </div><div id="mu">
+
+    <div id="page" class="area-single">
+      <div id="content">
+        <div class="area-detail">
+
+          <h1>Hena（ヘナ）</h1>
+          <div class="clearfix02 mb40">
+            <div class="profile float-l" id="3986">
+              <img src="http://image.eikaiwa.dmm.com/teacher/4178/f1990.jpg" alt="" class="profile-pic">
+              <iframe width="320" height="320" src="http://www.youtube.com/embed/4etcjEy4pNQ?rel=0" frameborder="0" class="profile-youtube" allowfullscreen></iframe>
+              <ul class="box-btn">
+                <li class="fav">
+                  <span><a href="#" class="favorite favorite-toggle" data-teacher-id="3986" data-button-type="3"><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/evalute_teacher/pc_heart_color.png" alt=""/> お気に入り登録済</a></span>                        </li>
+                <li><span class="btn-movie"><a href="#"><i class="ico"></i><span>動画を見る</span></a></span></li>
+              </ul>
+              <div class="favorite-list clearfix02">
+                <dl >
+                  <dt>ユーザーの評価</dt>
+                  <dd>
+                    <ul class="stars"><li><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/evalute_teacher/pc_star_yellow.png" alt=""/></li><li><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/evalute_teacher/pc_star_yellow.png" alt=""/></li><li><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/evalute_teacher/pc_star_yellow.png" alt=""/></li><li><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/evalute_teacher/pc_star_yellow.png" alt=""/></li><li><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/evalute_teacher/pc_star_half.png" alt=""/></li><li id="num">4.9</li></ul><p class="total" id="total">(1366件)</p>                            </dd>
+                </dl>
+                <dl>
+                  <dt>お気に入り</dt>
+                  <dd>
+                    <p class="gray"><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/evalute_teacher/pc_heart_noline.png"> <span id="fav_count">1763</span> 件</p>
+                  </dd>
+                </dl>
+              </div>
+              <!-- Add Recent Memo. 2017/02/27. -->
+              <!-- Add Recent Memo. 2017/02/27 End. -->
+            </div><!-- /profile -->
+
+
+            <div class="confirm low">
+              <dl>
+                <dt>国籍</dt>
+                <dd><img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/common/flag/bosnia_and_herzegovina.png" alt="" class="flag">ボスニア・ヘルツェゴビナ</dd>
+              </dl>
+              <dl>
+                <dt>誕生日</dt>
+                <dd>1996-04-14</dd>
+              </dl>
+              <dl>
+                <dt>性別</dt>
+                <dd>女性</dd>
+              </dl>
+              <dl>
+                <dt>経歴</dt>
+                <dd>3年以上</dd>
+              </dl>
+              <dl>
+                <dt>出身校</dt>
+                <dd>Information Science University</dd>
+              </dl>
+              <dl>
+                <dt>趣味</dt>
+                <dd>Dancing, playng tennis,reading books and watching movies :) And listening to music.. I love music :)</dd>
+              </dl>
+              <dl>
+                <dt>好きな映画</dt>
+                <dd>Avatar, Mr &amp; Mrs Smith, Hangover and Hachikō :)</dd>
+              </dl>
+              <dl>
+                <dt>特徴</dt>
+                <dd>
+                  <div class="search-special">
+                    <div class="special-checkbox" style="margin-left:0px; width:100%;">
+
+                      <label style="margin-bottom:0; margin-top:6px; margin-right:6px;cursor:default;">
+                        <img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/common/lecturer_icon.png">
+                        講師歴3年以上                                        </label>
+                      <label style="margin-bottom:0; margin-top:6px; margin-right:6px;cursor:default;">
+                        <img width="13" src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/common/business_english_icon.png">
+                        ビジネス英会話                                            </label>
+                      <label style="margin-bottom:0; margin-top:6px; margin-right:6px;cursor:default;">
+                        <img width="13" src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/common/beginner_icon.png">
+                        初心者向け                                            </label>
+                      <label style="margin-bottom:0; margin-top:6px; margin-right:6px;cursor:default;">
+                        <img width="13" src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/common/superiors_icon.png">
+                        上級者向け                                            </label>
+                      <label style="margin-bottom:0; margin-top:6px; margin-right:6px;cursor:default;">
+                        <img width="13" src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/common/speaking_test_icon.png">
+                        スピーキングテスト対応                                            </label>
+                      <label style="margin-bottom:0; margin-top:6px; margin-right:6px;cursor:default;">
+                        <img width="13" src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/common/ielts_icon.png">
+                        IELTS                                            </label>
+                      <div style="clear:both;"></div>
+                    </div>
+                  </div>
+                </dd>
+              </dl>
+            </div><!-- /confirm low float-l -->
+          </div>
+
+          <a name="detail-view"></a>
+          <div class="tab-navi">
+            <ul>
+              <li><a href="#tab01" id="lessonhistory">レッスン受講履歴(<span class="inner">12</span>)</a></li>
+              <li><a href="#tab02" id="message">先生からのメッセージ</a></li>
+              <li><a href="#tab03" id="staffcomment">スタッフコメント</a></li>
+              <li><a href="#tab04" id="ratecomment">評価・コメント</a></li>
+            </ul>
+          </div><!-- /tab-navi -->
+
+          <div id="tab01" class="tab-content">
+            <div class="area-lessonhistory">
+            </div><!-- /area-lessonhistory -->
+          </div><!-- /tab-content -->
+
+          <div id="tab02" class="tab-content">
+            <div class="area-message">
+            </div><!-- /area-message -->
+          </div><!-- /tab-content -->
+
+
+          <div id="tab03" class="tab-content">
+            <div class="area-staffcomment">
+              プログラミングを学んでいるヘナ先生です。英語講師としては、オンラインとオフライン合わせて2年の経験があります。先生にとって日本は楽しそうなバケーションスポットが一杯のきれいな国だそうです。いつか日本に旅行に行くことに憧れる先生に、日本のことをたくさん話してあげませんか？                </div><!-- /area-staffcomment -->
+          </div><!-- /tab-content -->
+
+
+          <div id="tab04" class="tab-content">
+            <div id="main-src" class="area-ratecomment">
+            </div><!-- /area-ratecomment -->
+          </div><!-- /tab-content -->
+
+
+          <div class="area-schedules">
+            <h2 class="mb0">スケジュール</h2>
+            <div class="area-search mt15 mb10">
+              <ul class="search-time">
+                <li class="on"><a href="#">すべての時間帯</a></li>
+                <li><a href="#">02:00-06:30</a></li>
+                <li><a href="#">07:00-11:30</a></li>
+                <li><a href="#">12:00-16:30</a></li>
+                <li><a href="#">17:00-21:30</a></li>
+                <li><a href="#">22:00-25:30</a></li>
+              </ul>
+              <!-- /area-search --></div>
+            <div class="schedules-list">
+              <ul class="time">
+                <li style="width:80px" ></li><!-- date header -->
+                <li class = 't-02-00' style="width:80px"><span>02:00-</span></li><li class = 't-02-30' style="width:80px"><span>02:30-</span></li><li class = 't-03-00' style="width:80px"><span>03:00-</span></li><li class = 't-03-30' style="width:80px"><span>03:30-</span></li><li class = 't-04-00' style="width:80px"><span>04:00-</span></li><li class = 't-04-30' style="width:80px"><span>04:30-</span></li><li class = 't-05-00' style="width:80px"><span>05:00-</span></li><li class = 't-05-30' style="width:80px"><span>05:30-</span></li><li class = 't-06-00' style="width:80px"><span>06:00-</span></li><li class = 't-06-30' style="width:80px"><span>06:30-</span></li><li class = 't-07-00' style="width:80px"><span>07:00-</span></li><li class = 't-07-30' style="width:80px"><span>07:30-</span></li><li class = 't-08-00' style="width:80px"><span>08:00-</span></li><li class = 't-08-30' style="width:80px"><span>08:30-</span></li><li class = 't-09-00' style="width:80px"><span>09:00-</span></li><li class = 't-09-30' style="width:80px"><span>09:30-</span></li><li class = 't-10-00' style="width:80px"><span>10:00-</span></li><li class = 't-10-30' style="width:80px"><span>10:30-</span></li><li class = 't-11-00' style="width:80px"><span>11:00-</span></li><li class = 't-11-30' style="width:80px"><span>11:30-</span></li><li class = 't-12-00' style="width:80px"><span>12:00-</span></li><li class = 't-12-30' style="width:80px"><span>12:30-</span></li><li class = 't-13-00' style="width:80px"><span>13:00-</span></li><li class = 't-13-30' style="width:80px"><span>13:30-</span></li><li class = 't-14-00' style="width:80px"><span>14:00-</span></li><li class = 't-14-30' style="width:80px"><span>14:30-</span></li><li class = 't-15-00' style="width:80px"><span>15:00-</span></li><li class = 't-15-30' style="width:80px"><span>15:30-</span></li><li class = 't-16-00' style="width:80px"><span>16:00-</span></li><li class = 't-16-30' style="width:80px"><span>16:30-</span></li><li class = 't-17-00' style="width:80px"><span>17:00-</span></li><li class = 't-17-30' style="width:80px"><span>17:30-</span></li><li class = 't-18-00' style="width:80px"><span>18:00-</span></li><li class = 't-18-30' style="width:80px"><span>18:30-</span></li><li class = 't-19-00' style="width:80px"><span>19:00-</span></li><li class = 't-19-30' style="width:80px"><span>19:30-</span></li><li class = 't-20-00' style="width:80px"><span>20:00-</span></li><li class = 't-20-30' style="width:80px"><span>20:30-</span></li><li class = 't-21-00' style="width:80px"><span>21:00-</span></li><li class = 't-21-30' style="width:80px"><span>21:30-</span></li><li class = 't-22-00' style="width:80px"><span>22:00-</span></li><li class = 't-22-30' style="width:80px"><span>22:30-</span></li><li class = 't-23-00' style="width:80px"><span>23:00-</span></li><li class = 't-23-30' style="width:80px"><span>23:30-</span></li><li class = 't-24-00' style="width:80px"><span>24:00-</span></li><li class = 't-24-30' style="width:80px"><span>24:30-</span></li><li class = 't-25-00' style="width:80px"><span>25:00-</span></li><li class = 't-25-30' style="width:80px"><span>25:30-</span></li>    </ul>
+              <ul class="oneday">
+                <li class="date" style="width:83px">03月01日<br>(木)</li>
+                <li class="t-02-00" style="width:83px"><span class="close">終了</span></li><li class="t-02-30" style="width:83px"><span class="close">終了</span></li><li class="t-03-00" style="width:83px"><span class="close">終了</span></li><li class="t-03-30" style="width:83px"><span class="close">終了</span></li><li class="t-04-00" style="width:83px"></li><li class="t-04-30" style="width:83px"></li><li class="t-05-00" style="width:83px"></li><li class="t-05-30" style="width:83px"></li><li class="t-06-00" style="width:83px"><span class="close">終了</span></li><li class="t-06-30" style="width:83px"><span class="close">終了</span></li><li class="t-07-00" style="width:83px"><span class="close">終了</span></li><li class="t-07-30" style="width:83px"><span class="close">終了</span></li><li class="t-08-00" style="width:83px"></li><li class="t-08-30" style="width:83px"></li><li class="t-09-00" style="width:83px"></li><li class="t-09-30" style="width:83px"></li><li class="t-10-00" style="width:83px"></li><li class="t-10-30" style="width:83px"></li><li class="t-11-00" style="width:83px"></li><li class="t-11-30" style="width:83px"></li><li class="t-12-00" style="width:83px"></li><li class="t-12-30" style="width:83px"></li><li class="t-13-00" style="width:83px"></li><li class="t-13-30" style="width:83px"></li><li class="t-14-00" style="width:83px"></li><li class="t-14-30" style="width:83px"></li><li class="t-15-00" style="width:83px"></li><li class="t-15-30" style="width:83px"></li><li class="t-16-00" style="width:83px"></li><li class="t-16-30" style="width:83px"></li><li class="t-17-00" style="width:83px"></li><li class="t-17-30" style="width:83px"></li><li class="t-18-00" style="width:83px"><span class="close">終了</span></li><li class="t-18-30" style="width:83px"><span class="close">終了</span></li><li class="t-19-00" style="width:83px"><span class="close">終了</span></li><li class="t-19-30" style="width:83px"><span class="close">終了</span></li><li class="t-20-00" style="width:83px"></li><li class="t-20-30" style="width:83px"></li><li class="t-21-00" style="width:83px"><span class="close">終了</span></li><li class="t-21-30" style="width:83px"><span class="close">終了</span></li><li class="t-22-00" style="width:83px"><span class="close">終了</span></li><li class="t-22-30" style="width:83px"><span class="close">終了</span></li><li class="t-23-00" style="width:83px"></li><li class="t-23-30" style="width:83px"><span class="close">終了</span></li><li class="t-24-00" style="width:83px"><span class="close">予約済</span></li><li class="t-24-30" style="width:83px"><span class="close">予約済</span></li><li class="t-25-00" style="width:83px"><span class="close">予約済</span></li><li class="t-25-30" style="width:83px"></li>            </ul>
+              <ul class="oneday">
+                <li class="date" style="width:83px">03月02日<br>(金)</li>
+                <li class="t-02-00" style="width:83px"><span class="close">予約済</span></li><li class="t-02-30" style="width:83px"><span class="close">予約済</span></li><li class="t-03-00" style="width:83px"></li><li class="t-03-30" style="width:83px"></li><li class="t-04-00" style="width:83px"></li><li class="t-04-30" style="width:83px"></li><li class="t-05-00" style="width:83px"></li><li class="t-05-30" style="width:83px"></li><li class="t-06-00" style="width:83px"><span class="close">予約済</span></li><li class="t-06-30" style="width:83px"><span class="close">予約済</span></li><li class="t-07-00" style="width:83px"><span class="close">予約済</span></li><li class="t-07-30" style="width:83px"><span class="close">予約済</span></li><li class="t-08-00" style="width:83px"></li><li class="t-08-30" style="width:83px"></li><li class="t-09-00" style="width:83px"></li><li class="t-09-30" style="width:83px"></li><li class="t-10-00" style="width:83px"></li><li class="t-10-30" style="width:83px"></li><li class="t-11-00" style="width:83px"></li><li class="t-11-30" style="width:83px"></li><li class="t-12-00" style="width:83px"></li><li class="t-12-30" style="width:83px"></li><li class="t-13-00" style="width:83px"></li><li class="t-13-30" style="width:83px"></li><li class="t-14-00" style="width:83px"></li><li class="t-14-30" style="width:83px"></li><li class="t-15-00" style="width:83px"></li><li class="t-15-30" style="width:83px"></li><li class="t-16-00" style="width:83px"></li><li class="t-16-30" style="width:83px"></li><li class="t-17-00" style="width:83px"></li><li class="t-17-30" style="width:83px"></li><li class="t-18-00" style="width:83px"><span class="close">予約済</span></li><li class="t-18-30" style="width:83px"><span class="close">予約済</span></li><li class="t-19-00" style="width:83px"><span class="close">予約済</span></li><li class="t-19-30" style="width:83px"></li><li class="t-20-00" style="width:83px"></li><li class="t-20-30" style="width:83px"></li><li class="t-21-00" style="width:83px"><span class="close">予約済</span></li><li class="t-21-30" style="width:83px"><span class="close">予約済</span></li><li class="t-22-00" style="width:83px"><span class="close">予約済</span></li><li class="t-22-30" style="width:83px"><span class="close">予約済</span></li><li class="t-23-00" style="width:83px"></li><li class="t-23-30" style="width:83px"><span class="close">予約済</span></li><li class="t-24-00" style="width:83px"><span class="close">予約済</span></li><li class="t-24-30" style="width:83px"><span class="close">予約済</span></li><li class="t-25-00" style="width:83px"><span class="close">予約済</span></li><li class="t-25-30" style="width:83px"></li>            </ul>
+              <ul class="oneday">
+                <li class="date" style="width:83px">03月03日<br>(土)</li>
+                <li class="t-02-00" style="width:83px"><span class="close">予約済</span></li><li class="t-02-30" style="width:83px"><a href="#" class="bt-open" id="a:4:{s:8:&quot;launched&quot;;s:19:&quot;2018-03-03 02:30:00&quot;;s:10:&quot;teacher_id&quot;;s:4:&quot;3986&quot;;s:9:&quot;lesson_id&quot;;s:8:&quot;48011906&quot;;s:16:&quot;from_recommended&quot;;N;}">予約可</a></li><li class="t-03-00" style="width:83px"><a href="#" class="bt-open" id="a:4:{s:8:&quot;launched&quot;;s:19:&quot;2018-03-03 03:00:00&quot;;s:10:&quot;teacher_id&quot;;s:4:&quot;3986&quot;;s:9:&quot;lesson_id&quot;;s:8:&quot;48011909&quot;;s:16:&quot;from_recommended&quot;;N;}">予約可</a></li><li class="t-03-30" style="width:83px"><span class="close">予約済</span></li><li class="t-04-00" style="width:83px"></li><li class="t-04-30" style="width:83px"></li><li class="t-05-00" style="width:83px"><a href="#" class="bt-open" id="a:4:{s:8:&quot;launched&quot;;s:19:&quot;2018-03-03 05:00:00&quot;;s:10:&quot;teacher_id&quot;;s:4:&quot;3986&quot;;s:9:&quot;lesson_id&quot;;s:8:&quot;48066619&quot;;s:16:&quot;from_recommended&quot;;N;}">予約可</a></li><li class="t-05-30" style="width:83px"><a href="#" class="bt-open" id="a:4:{s:8:&quot;launched&quot;;s:19:&quot;2018-03-03 05:30:00&quot;;s:10:&quot;teacher_id&quot;;s:4:&quot;3986&quot;;s:9:&quot;lesson_id&quot;;s:8:&quot;48066620&quot;;s:16:&quot;from_recommended&quot;;N;}">予約可</a></li><li class="t-06-00" style="width:83px"><a href="#" class="bt-open" id="a:4:{s:8:&quot;launched&quot;;s:19:&quot;2018-03-03 06:00:00&quot;;s:10:&quot;teacher_id&quot;;s:4:&quot;3986&quot;;s:9:&quot;lesson_id&quot;;s:8:&quot;48011915&quot;;s:16:&quot;from_recommended&quot;;N;}">予約可</a></li><li class="t-06-30" style="width:83px"><a href="#" class="bt-open" id="a:4:{s:8:&quot;launched&quot;;s:19:&quot;2018-03-03 06:30:00&quot;;s:10:&quot;teacher_id&quot;;s:4:&quot;3986&quot;;s:9:&quot;lesson_id&quot;;s:8:&quot;48011918&quot;;s:16:&quot;from_recommended&quot;;N;}">予約可</a></li><li class="t-07-00" style="width:83px"></li><li class="t-07-30" style="width:83px"></li><li class="t-08-00" style="width:83px"></li><li class="t-08-30" style="width:83px"></li><li class="t-09-00" style="width:83px"></li><li class="t-09-30" style="width:83px"></li><li class="t-10-00" style="width:83px"></li><li class="t-10-30" style="width:83px"></li><li class="t-11-00" style="width:83px"></li><li class="t-11-30" style="width:83px"></li><li class="t-12-00" style="width:83px"></li><li class="t-12-30" style="width:83px"></li><li class="t-13-00" style="width:83px"></li><li class="t-13-30" style="width:83px"></li><li class="t-14-00" style="width:83px"></li><li class="t-14-30" style="width:83px"></li><li class="t-15-00" style="width:83px"></li><li class="t-15-30" style="width:83px"></li><li class="t-16-00" style="width:83px"></li><li class="t-16-30" style="width:83px"></li><li class="t-17-00" style="width:83px"></li><li class="t-17-30" style="width:83px"></li><li class="t-18-00" style="width:83px"></li><li class="t-18-30" style="width:83px"></li><li class="t-19-00" style="width:83px"></li><li class="t-19-30" style="width:83px"></li><li class="t-20-00" style="width:83px"></li><li class="t-20-30" style="width:83px"></li><li class="t-21-00" style="width:83px"></li><li class="t-21-30" style="width:83px"></li><li class="t-22-00" style="width:83px"></li><li class="t-22-30" style="width:83px"></li><li class="t-23-00" style="width:83px"></li><li class="t-23-30" style="width:83px"></li><li class="t-24-00" style="width:83px"></li><li class="t-24-30" style="width:83px"></li><li class="t-25-00" style="width:83px"></li><li class="t-25-30" style="width:83px"></li>            </ul>
+              <ul class="oneday">
+                <li class="date" style="width:83px">03月04日<br>(日)</li>
+                <li class="t-02-00" style="width:83px"></li><li class="t-02-30" style="width:83px"></li><li class="t-03-00" style="width:83px"></li><li class="t-03-30" style="width:83px"></li><li class="t-04-00" style="width:83px"></li><li class="t-04-30" style="width:83px"></li><li class="t-05-00" style="width:83px"></li><li class="t-05-30" style="width:83px"></li><li class="t-06-00" style="width:83px"></li><li class="t-06-30" style="width:83px"></li><li class="t-07-00" style="width:83px"></li><li class="t-07-30" style="width:83px"></li><li class="t-08-00" style="width:83px"></li><li class="t-08-30" style="width:83px"></li><li class="t-09-00" style="width:83px"></li><li class="t-09-30" style="width:83px"></li><li class="t-10-00" style="width:83px"></li><li class="t-10-30" style="width:83px"></li><li class="t-11-00" style="width:83px"></li><li class="t-11-30" style="width:83px"></li><li class="t-12-00" style="width:83px"></li><li class="t-12-30" style="width:83px"></li><li class="t-13-00" style="width:83px"></li><li class="t-13-30" style="width:83px"></li><li class="t-14-00" style="width:83px"></li><li class="t-14-30" style="width:83px"></li><li class="t-15-00" style="width:83px"></li><li class="t-15-30" style="width:83px"></li><li class="t-16-00" style="width:83px"></li><li class="t-16-30" style="width:83px"></li><li class="t-17-00" style="width:83px"></li><li class="t-17-30" style="width:83px"></li><li class="t-18-00" style="width:83px"></li><li class="t-18-30" style="width:83px"></li><li class="t-19-00" style="width:83px"></li><li class="t-19-30" style="width:83px"></li><li class="t-20-00" style="width:83px"></li><li class="t-20-30" style="width:83px"></li><li class="t-21-00" style="width:83px"></li><li class="t-21-30" style="width:83px"></li><li class="t-22-00" style="width:83px"></li><li class="t-22-30" style="width:83px"></li><li class="t-23-00" style="width:83px"></li><li class="t-23-30" style="width:83px"></li><li class="t-24-00" style="width:83px"></li><li class="t-24-30" style="width:83px"></li><li class="t-25-00" style="width:83px"></li><li class="t-25-30" style="width:83px"></li>            </ul>
+              <ul class="oneday">
+                <li class="date" style="width:83px">03月05日<br>(月)</li>
+                <li class="t-02-00" style="width:83px"></li><li class="t-02-30" style="width:83px"></li><li class="t-03-00" style="width:83px"></li><li class="t-03-30" style="width:83px"></li><li class="t-04-00" style="width:83px"></li><li class="t-04-30" style="width:83px"></li><li class="t-05-00" style="width:83px"></li><li class="t-05-30" style="width:83px"></li><li class="t-06-00" style="width:83px"></li><li class="t-06-30" style="width:83px"></li><li class="t-07-00" style="width:83px"></li><li class="t-07-30" style="width:83px"></li><li class="t-08-00" style="width:83px"></li><li class="t-08-30" style="width:83px"></li><li class="t-09-00" style="width:83px"></li><li class="t-09-30" style="width:83px"></li><li class="t-10-00" style="width:83px"></li><li class="t-10-30" style="width:83px"></li><li class="t-11-00" style="width:83px"></li><li class="t-11-30" style="width:83px"></li><li class="t-12-00" style="width:83px"></li><li class="t-12-30" style="width:83px"></li><li class="t-13-00" style="width:83px"></li><li class="t-13-30" style="width:83px"></li><li class="t-14-00" style="width:83px"></li><li class="t-14-30" style="width:83px"></li><li class="t-15-00" style="width:83px"></li><li class="t-15-30" style="width:83px"></li><li class="t-16-00" style="width:83px"></li><li class="t-16-30" style="width:83px"></li><li class="t-17-00" style="width:83px"></li><li class="t-17-30" style="width:83px"></li><li class="t-18-00" style="width:83px"></li><li class="t-18-30" style="width:83px"></li><li class="t-19-00" style="width:83px"></li><li class="t-19-30" style="width:83px"></li><li class="t-20-00" style="width:83px"></li><li class="t-20-30" style="width:83px"></li><li class="t-21-00" style="width:83px"></li><li class="t-21-30" style="width:83px"></li><li class="t-22-00" style="width:83px"></li><li class="t-22-30" style="width:83px"></li><li class="t-23-00" style="width:83px"></li><li class="t-23-30" style="width:83px"></li><li class="t-24-00" style="width:83px"></li><li class="t-24-30" style="width:83px"></li><li class="t-25-00" style="width:83px"></li><li class="t-25-30" style="width:83px"></li>            </ul>
+              <ul class="oneday">
+                <li class="date" style="width:83px">03月06日<br>(火)</li>
+                <li class="t-02-00" style="width:83px"></li><li class="t-02-30" style="width:83px"></li><li class="t-03-00" style="width:83px"></li><li class="t-03-30" style="width:83px"></li><li class="t-04-00" style="width:83px"></li><li class="t-04-30" style="width:83px"></li><li class="t-05-00" style="width:83px"></li><li class="t-05-30" style="width:83px"></li><li class="t-06-00" style="width:83px"></li><li class="t-06-30" style="width:83px"></li><li class="t-07-00" style="width:83px"></li><li class="t-07-30" style="width:83px"></li><li class="t-08-00" style="width:83px"></li><li class="t-08-30" style="width:83px"></li><li class="t-09-00" style="width:83px"></li><li class="t-09-30" style="width:83px"></li><li class="t-10-00" style="width:83px"></li><li class="t-10-30" style="width:83px"></li><li class="t-11-00" style="width:83px"></li><li class="t-11-30" style="width:83px"></li><li class="t-12-00" style="width:83px"></li><li class="t-12-30" style="width:83px"></li><li class="t-13-00" style="width:83px"></li><li class="t-13-30" style="width:83px"></li><li class="t-14-00" style="width:83px"></li><li class="t-14-30" style="width:83px"></li><li class="t-15-00" style="width:83px"></li><li class="t-15-30" style="width:83px"></li><li class="t-16-00" style="width:83px"></li><li class="t-16-30" style="width:83px"></li><li class="t-17-00" style="width:83px"></li><li class="t-17-30" style="width:83px"></li><li class="t-18-00" style="width:83px"></li><li class="t-18-30" style="width:83px"></li><li class="t-19-00" style="width:83px"></li><li class="t-19-30" style="width:83px"></li><li class="t-20-00" style="width:83px"></li><li class="t-20-30" style="width:83px"></li><li class="t-21-00" style="width:83px"></li><li class="t-21-30" style="width:83px"></li><li class="t-22-00" style="width:83px"></li><li class="t-22-30" style="width:83px"></li><li class="t-23-00" style="width:83px"></li><li class="t-23-30" style="width:83px"></li><li class="t-24-00" style="width:83px"></li><li class="t-24-30" style="width:83px"></li><li class="t-25-00" style="width:83px"></li><li class="t-25-30" style="width:83px"></li>            </ul>
+              <ul class="oneday">
+                <li class="date" style="width:83px">03月07日<br>(水)</li>
+                <li class="t-02-00" style="width:83px"></li><li class="t-02-30" style="width:83px"></li><li class="t-03-00" style="width:83px"></li><li class="t-03-30" style="width:83px"></li><li class="t-04-00" style="width:83px"></li><li class="t-04-30" style="width:83px"></li><li class="t-05-00" style="width:83px"></li><li class="t-05-30" style="width:83px"></li><li class="t-06-00" style="width:83px"></li><li class="t-06-30" style="width:83px"></li><li class="t-07-00" style="width:83px"></li><li class="t-07-30" style="width:83px"></li><li class="t-08-00" style="width:83px"></li><li class="t-08-30" style="width:83px"></li><li class="t-09-00" style="width:83px"></li><li class="t-09-30" style="width:83px"></li><li class="t-10-00" style="width:83px"></li><li class="t-10-30" style="width:83px"></li><li class="t-11-00" style="width:83px"></li><li class="t-11-30" style="width:83px"></li><li class="t-12-00" style="width:83px"></li><li class="t-12-30" style="width:83px"></li><li class="t-13-00" style="width:83px"></li><li class="t-13-30" style="width:83px"></li><li class="t-14-00" style="width:83px"></li><li class="t-14-30" style="width:83px"></li><li class="t-15-00" style="width:83px"></li><li class="t-15-30" style="width:83px"></li><li class="t-16-00" style="width:83px"></li><li class="t-16-30" style="width:83px"></li><li class="t-17-00" style="width:83px"></li><li class="t-17-30" style="width:83px"></li><li class="t-18-00" style="width:83px"></li><li class="t-18-30" style="width:83px"></li><li class="t-19-00" style="width:83px"></li><li class="t-19-30" style="width:83px"></li><li class="t-20-00" style="width:83px"></li><li class="t-20-30" style="width:83px"></li><li class="t-21-00" style="width:83px"></li><li class="t-21-30" style="width:83px"></li><li class="t-22-00" style="width:83px"></li><li class="t-22-30" style="width:83px"></li><li class="t-23-00" style="width:83px"></li><li class="t-23-30" style="width:83px"></li><li class="t-24-00" style="width:83px"></li><li class="t-24-30" style="width:83px"></li><li class="t-25-00" style="width:83px"></li><li class="t-25-30" style="width:83px"></li>            </ul>
+            </div><!-- /schedules-list -->
+          </div><!-- /area-schedules -->
+
+          <div id="popup-limit">
+            <div class="cover"></div>
+            <div class="box">
+              <p class="lead">申し訳ありません</p>
+              <p id="pop-message">「予約可能数」が1以上ある場合は、新たに次のご予約が可能です。<br>
+                0の場合は、予約中のレッスンを受講後に次のご予約をお取りできます。</p>
+              <ul id="charge-link">
+                <li><a href="/book/book_list/" class="arrow h_underline">予約状況を確認する</a></li>
+                <li><a href="http://help.dmm.com/-/detail/=/qid=29168/" class="arrow h_underline">予約可能数の仕組みについて</a></li>
+              </ul>
+              <p class="mg-t20" id="free-link"><a href="/plan/" class="arrow h_underline">料金プラン</a></p>
+              <img src="http://image.eikaiwa.dmm.com/assets/p/general/eikaiwa/lesson/bt_close.gif" alt="" class="bt-close">
+            </div>
+          </div><!-- [ #popup-limit ] -->
+
+        </div><!-- /area-detail -->
+      </div><!-- [ #content ] -->
+
+
+    </div><!-- [ #page ] -->
+
+    <script type="text/javascript">
+      //時間帯設定した場合の表示処理
+      $(function() {
+
+        var onedayHeader = $('.schedules-list ul').find("li:first");
+        var onedayHeaderTop = onedayHeader.offset().top;
+        var $w = $(window);
+        var isFixed = false;
+        $w.scroll(function() {
+          var shouldBeFixed = $w.scrollTop() > onedayHeaderTop;
+          if (shouldBeFixed && !isFixed) {
+            onedayHeader.css({
+              position: 'fixed',
+              top:0,
+            });
+            isFixed = true;
+          }else if (!shouldBeFixed && isFixed){
+            onedayHeader.css({
+              position: 'static'
+            });
+            isFixed = false;
+          }
+        });
+
+      });
+      //list backgroundColor
+      $(".time li:nth-child(2n+1)").css("background-color","#ebebeb");
+      $(".oneday li:nth-child(2n+1)").css("background-color","#fff");
+
+      // R3/T - 時間帯切り替え
+      $('.search-time li a').click(function() {
+        var selected = $(".search-time li a").index(this);
+        slideSchedule(selected);
+
+        return false;
+
+      });
+      jQuery(function($){
+        // Recent Memo Box If Text Overflow Cut & Replace Script.
+        var target = $('#recent_memo dd span.inner'),
+          count = target.text().length,
+          limit = 95;
+        if(count > limit){
+          var getTxt = target.text(),
+            cutTxt = getTxt.substr(0,(limit));
+          target.html(cutTxt + '…');
+        }
+      });
+    </script>
+    <script src="http://www.dmm.com/js/bugfix.js" charset="UTF-8"></script>
+    <script src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async></script>
+    <script src="http://static.mixi.jp/js/share.js" async></script>
+    <script src="http://platform.twitter.com/widgets.js" charset="utf-8"></script>
+    <script src="http://connect.facebook.net/ja_JP/all.js#xfbml=1"></script>
+    <script src="http://www.dmm.com/js/social_analyzer.js"></script>
+
+    <script type="text/javascript">
+      /* <![CDATA[ */
+      var google_conversion_id = 982701367;
+      var google_custom_params = window.google_tag_params;
+      var google_remarketing_only = true;
+      /* ]]> */
+    </script>
+    <script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
+    </script>
+    <noscript>
+      <div style="display:inline;">
+        <img height="1" width="1" style="border-style:none;" alt="" src="//googleads.g.doubleclick.net/pagead/viewthroughconversion/982701367/?value=0&amp;guid=ON&amp;script=0"/>
+      </div>
+    </noscript>
+
+    <script type="text/javascript">
+      var _fout_queue = _fout_queue || {}; if (_fout_queue.segment === void 0) _fout_queue.segment = {};
+      if (_fout_queue.segment.queue === void 0) _fout_queue.segment.queue = [];
+
+      _fout_queue.segment.queue.push({
+        'user_id': 4250
+      });
+
+      (function() {
+        var el = document.createElement('script'); el.type = 'text/javascript'; el.async = true;
+        el.src = (('https:' == document.location.protocol) ? 'https://' : 'http://') + 'js.fout.jp/segmentation.js';
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(el, s);
+      })();
+    </script>
+
+    <script src="//ad.yieldmanager.com/pixel?id=2413777&t=1" type="text/javascript"></script>
+  </div></div></div>
+
+<div class="n_pop_up show">
+  <div class="cancelled_lesson">
+    <p class="title">
+      こちらのレッスンは既にキャンセルしているため再予約できません。同時刻・同講師での再予約はできませんので、他の時間帯もしくは他の講師にてご予約下さい。
+    </p>
+    <p class="button">
+      <a href="#" class="change close">戻る</a>
+    </p>
+  </div>
+
+  <div class="native_plan_popup">
+    <p class="title">
+      ネイティブ講師の予約はプラスネイティブプラン会員の方のみ可能となります。
+    </p>
+    　　     <p class="button">
+    <a href="/lp/plusnative/" class="plan">プラスネイティブプランについて詳しくはこちら</a>
+  </p>
+
+    <img src="http://image.eikaiwa.dmm.com/assets/p/sp/general/eikaiwa/common/close_button.png" class="close close_btn" id="close_btn">
+  </div>        </div>
+
+<div class="recent-achievement-modal"></div>
+
+
+<style type="text/css"><!--
+#dmm_remote {
+  margin: 0;
+  padding: 0 12px;
+  background-color: #242424;
+}
+#dmm_remote * {
+  line-height: 1.3;
+}
+#dmm_remote #footer {
+  margin-top: 0;
+}
+#dmm_remote p.anchor {
+  margin: 0;
+  padding: 12px;
+  background-color: #fff;
+}
+--></style>
+
+<div id="footer">
+  <p class="anchor">
+    <a href="#top" class="d-txttopback">このページのトップへ</a>
+  </p>
+  <div class="wp-info">
+    <ul class="info">
+      <li>
+        <p>DMM英会話 ご利用ガイド</p>
+        <ul>
+          <li><a href="http://eikaiwa.dmm.com/guide/top/" target="_top">初めての方はこちら</a></li>
+
+          <li><a href="http://eikaiwa.dmm.com/guide/lesson_top/" target="_top">登録・ご利用方法</a></li>
+
+          <li><a href="http://help.dmm.com/-/list/=/mid=291/" target="_blank">よくある質問</a></li>
+
+        </ul>
+      </li>
+      <li>
+        <p>お問い合わせ・規約</p>
+        <ul>
+          <li><a href="http://www.dmm.com/help/faq_support.html" target="_top">お問い合わせはこちら</a></li>
+
+          <li><a href="http://www.dmm.com/rule/=/category=eikaiwa/" target="_blank">DMM英会話 利用規約</a></li>
+
+        </ul>
+      </li>
+      <li>
+        <p>お得な情報</p>
+        <ul>
+
+          <li><a href="http://www.dmm.com/information/mail_magazine/" target="_top">DMMメールマガジン</a><br><span>お得な情報を無料でお届けします。</span></li>
+          <li><a href="http://affiliate.dmm.com/" target="_top">DMMアフィリエイト</a><br><span>DMMの商品を紹介して広告収入をゲット！</span></li>
+          <li><a href="http://affiliate-fx.dmm.com/" target="_top">DMM FX/CFDアフィリエイト</a><br>
+            <span>DMM FX/CFDを紹介して広告収入をゲット！</span></li>
+        </ul>
+      </li>
+    </ul>
+    <!-- /.wp-info --></div>
+  <ul class="ft-nav">
+    <li><a href="https://terms.dmm.com/profile/">会社概要</a></li>
+    <li><a href="https://dmm-corp.com/press/" target="_blank">プレスリリース</a></li>
+    <li><a href="https://terms.dmm.com/member/" rel="nofollow">会員規約</a></li>
+    <li><a href="https://terms.dmm.com/privacy/" rel="nofollow">個人情報保護に関して</a></li>
+    <li><a href="https://terms.dmm.com/commerce/" rel="nofollow">特定商取引法に基づく表示</a></li>
+    <li><a href="https://dmm-corp.com/recruit/" target="_blank">スタッフ募集</a></li>
+    <li class="last"><a href="https://terms.dmm.com/partner/">ビジネスパートナー募集</a></li>
+  </ul>
+  <p class="copy"><small>Copyright &copy; since 1998 DMM All Rights Reserved.</small></p>
+  <!-- /footer --></div>
+<script type="text/javascript" src="/js/favorite_toggle.js?1491376692"></script><script type="text/javascript" src="/js/react/static/js/main.js?1519793335"></script><!--[if IE 7]></div><![endif]-->
+</body>
+</html>

--- a/backend/infrastructure/mysql/lesson.go
+++ b/backend/infrastructure/mysql/lesson.go
@@ -1,0 +1,15 @@
+package mysql
+
+import (
+	"database/sql"
+
+	"github.com/oinume/lekcije/backend/domain/repository"
+)
+
+type lessonRepository struct {
+	db *sql.DB
+}
+
+func NewLessonRepository(db *sql.DB) repository.Lesson {
+	return &lessonRepository{db: db}
+}

--- a/backend/infrastructure/mysql/user.go
+++ b/backend/infrastructure/mysql/user.go
@@ -69,6 +69,13 @@ func (r *userRepository) findByGoogleIDWithExec(ctx context.Context, exec reposi
 	return u, nil
 }
 
+func (r *userRepository) FindAllByEmailVerified(
+	ctx context.Context, notificationInterval int,
+) ([]*model2.User, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (r *userRepository) UpdateEmail(ctx context.Context, id uint, email string) error {
 	const query = `UPDATE user SET email = ?, updated_at = NOW() WHERE id = ?`
 	_, err := queries.Raw(query, email, id).ExecContext(ctx, r.db)

--- a/backend/interface/http/twrip_me_test.go
+++ b/backend/interface/http/twrip_me_test.go
@@ -590,9 +590,10 @@ func Test_MeService_UpdateMeNotificationTimeSpan(t *testing.T) {
 
 func newMeService(db *gorm.DB, appLogger *zap.Logger) api_v1.Me {
 	gaMeasurement := usecase.NewGAMeasurement(ga_measurement.NewGAMeasurementRepository(ga_measurement.NewFakeClient()))
+	mCountryList := di.MustNewMCountryList(context.Background(), db.DB())
 	return interface_http.NewMeService(
 		db, appLogger,
-		di.NewFollowingTeacherUsecase(appLogger, db.DB()),
+		di.NewFollowingTeacherUsecase(appLogger, db.DB(), mCountryList),
 		gaMeasurement,
 		di.NewNotificationTimeSpanUsecase(db.DB()),
 		di.NewUserUsecase(db.DB()),

--- a/backend/internal/mock/mock_transport.go
+++ b/backend/internal/mock/mock_transport.go
@@ -1,0 +1,51 @@
+package mock
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+)
+
+type HTMLTransport struct {
+	sync.Mutex
+	NumCalled int
+	content   string
+}
+
+func NewHTMLTransport(path string) (*HTMLTransport, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("os.Open failed: path=%v, err=%v", path, err)
+	}
+	b, err := ioutil.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("read file failed: err=%v", err)
+	}
+	return &HTMLTransport{
+		content: string(b),
+	}, nil
+}
+
+func NewMockTransportFromHTML(content string) *HTMLTransport {
+	return &HTMLTransport{
+		content: content,
+	}
+}
+
+func (t *HTMLTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.Lock()
+	t.NumCalled++
+	t.Unlock()
+	resp := &http.Response{
+		Header:     make(http.Header),
+		Request:    req,
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+	}
+	resp.Header.Set("Content-Type", "text/html; charset=UTF-8")
+	resp.Body = ioutil.NopCloser(strings.NewReader(t.content))
+	return resp, nil
+}

--- a/backend/internal/modeltest/modeltest.go
+++ b/backend/internal/modeltest/modeltest.go
@@ -54,12 +54,15 @@ func NewTeacher(setters ...func(u *model2.Teacher)) *model2.Teacher {
 	if teacher.Name == "" {
 		teacher.Name = "teacher " + randoms.MustNewString(8)
 	}
+	if teacher.Gender == "" {
+		teacher.Gender = "female"
+	}
 	if teacher.Birthday.IsZero() {
 		teacher.Birthday = time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC)
 	}
-	if teacher.LastLessonAt.IsZero() {
-		teacher.LastLessonAt = time.Now().UTC().Add(72 * time.Hour)
-	}
+	//if teacher.LastLessonAt.IsZero() {
+	//	teacher.LastLessonAt = time.Now().UTC().Add(72 * time.Hour)
+	//}
 	return teacher
 }
 

--- a/backend/model2/lesson_helper.go
+++ b/backend/model2/lesson_helper.go
@@ -1,0 +1,17 @@
+package model2
+
+import "github.com/oinume/goenum"
+
+type LessonStatus struct {
+	Finished  int `goenum:"終了"`
+	Reserved  int `goenum:"予約済"`
+	Available int `goenum:"予約可"`
+	Cancelled int `goenum:"休講"`
+}
+
+var LessonStatuses = goenum.EnumerateStruct(&LessonStatus{
+	Finished:  1,
+	Reserved:  2,
+	Available: 3,
+	Cancelled: 4,
+})

--- a/backend/model2/m_country_helper.go
+++ b/backend/model2/m_country_helper.go
@@ -9,7 +9,7 @@ func (mc *MCountryList) GetByNameJA(name string) (*MCountry, bool) {
 	return c, ok
 }
 
-func NewMCountries(values []*MCountry) *MCountryList {
+func NewMCountryList(values []*MCountry) *MCountryList {
 	c := &MCountryList{
 		byNameJa: make(map[string]*MCountry, 1000),
 	}

--- a/backend/model2/m_country_helper.go
+++ b/backend/model2/m_country_helper.go
@@ -1,0 +1,20 @@
+package model2
+
+type MCountryList struct {
+	byNameJa map[string]*MCountry
+}
+
+func (mc *MCountryList) GetByNameJA(name string) (*MCountry, bool) {
+	c, ok := mc.byNameJa[name]
+	return c, ok
+}
+
+func NewMCountries(values []*MCountry) *MCountryList {
+	c := &MCountryList{
+		byNameJa: make(map[string]*MCountry, 1000),
+	}
+	for _, v := range values {
+		c.byNameJa[v.NameJa] = v
+	}
+	return c
+}

--- a/backend/model2/teacher_custom.go
+++ b/backend/model2/teacher_custom.go
@@ -1,0 +1,13 @@
+package model2
+
+import "fmt"
+
+const teacherURLBase = "https://eikaiwa.dmm.com/teacher/index/%v/"
+
+func (o *Teacher) URL() string {
+	return fmt.Sprintf(teacherURLBase, o.ID)
+}
+
+func (o *Teacher) IsJapanese() bool {
+	return o.CountryID == 392
+}

--- a/backend/notifier/notifier_test.go
+++ b/backend/notifier/notifier_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/oinume/lekcije/backend/domain/repository"
 	"github.com/oinume/lekcije/backend/emailer"
 	"github.com/oinume/lekcije/backend/fetcher"
+	"github.com/oinume/lekcije/backend/internal/mock"
 	"github.com/oinume/lekcije/backend/logger"
 	"github.com/oinume/lekcije/backend/model"
 	"github.com/oinume/lekcije/backend/usecase"
@@ -138,7 +139,7 @@ func TestNotifier_SendNotification(t *testing.T) {
 	db := helper.DB(t)
 	appLogger := logger.NewAppLogger(os.Stdout, zapcore.DebugLevel)
 
-	fetcherMockTransport, err := fetcher.NewMockTransport("../fetcher/testdata/3986.html")
+	fetcherMockTransport, err := mock.NewHTMLTransport("../fetcher/testdata/3986.html")
 	if err != nil {
 		t.Fatalf("fetcher.NewMockTransport failed: err=%v", err)
 	}
@@ -240,7 +241,7 @@ func TestNotifier_Close(t *testing.T) {
 	db := helper.DB(t)
 	appLogger := logger.NewAppLogger(os.Stdout, zapcore.DebugLevel)
 
-	fetcherMockTransport, err := fetcher.NewMockTransport("../fetcher/testdata/3986.html")
+	fetcherMockTransport, err := mock.NewHTMLTransport("../fetcher/testdata/3986.html")
 	r.NoError(err, "fetcher.NewMockTransport failed")
 	fetcherHTTPClient := &http.Client{
 		Transport: fetcherMockTransport,

--- a/backend/usecase/following_teacher.go
+++ b/backend/usecase/following_teacher.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/oinume/lekcije/backend/domain/repository"
 	"github.com/oinume/lekcije/backend/errors"
-	"github.com/oinume/lekcije/backend/infrastructure/dmm_eikaiwa"
 	"github.com/oinume/lekcije/backend/model2"
 )
 
@@ -18,26 +17,26 @@ type FollowingTeacher struct {
 	appLogger            *zap.Logger
 	dbRepo               repository.DB
 	followingTeacherRepo repository.FollowingTeacher
-	mCountryRepo         repository.MCountry
 	userRepo             repository.User
 	teacherRepo          repository.Teacher
+	lessonFetcherRepo    repository.LessonFetcher
 }
 
 func NewFollowingTeacher(
 	appLogger *zap.Logger,
 	dbRepo repository.DB,
 	followingTeacherRepo repository.FollowingTeacher,
-	mCountryRepo repository.MCountry,
 	userRepo repository.User,
 	teacherRepo repository.Teacher,
+	lessonFetcherRepo repository.LessonFetcher,
 ) *FollowingTeacher {
 	return &FollowingTeacher{
 		appLogger:            appLogger,
 		dbRepo:               dbRepo,
 		followingTeacherRepo: followingTeacherRepo,
-		mCountryRepo:         mCountryRepo,
 		userRepo:             userRepo,
 		teacherRepo:          teacherRepo,
+		lessonFetcherRepo:    lessonFetcherRepo,
 	}
 }
 
@@ -76,14 +75,8 @@ func (u *FollowingTeacher) FollowTeacher(ctx context.Context, user *model2.User,
 		updateFollowedTeacherAt = true
 	}
 
-	mCountries, err := u.mCountryRepo.FindAll(ctx)
-	if err != nil {
-		return false, err
-	}
-	// TODO: DI
-	fetcher := dmm_eikaiwa.NewLessonFetcher(nil, 1, false, model2.NewMCountryList(mCountries), u.appLogger)
-	defer fetcher.Close()
-	fetchedTeacher, _, err := fetcher.Fetch(ctx, teacher.ID)
+	// TODO: Close
+	fetchedTeacher, _, err := u.lessonFetcherRepo.Fetch(ctx, teacher.ID)
 	if err != nil {
 		return false, err
 	}

--- a/backend/usecase/notification.go
+++ b/backend/usecase/notification.go
@@ -1,0 +1,27 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/oinume/lekcije/backend/model2"
+)
+
+type Notification struct {
+}
+
+func NewNotification() *Notification {
+	return &Notification{}
+}
+
+func (n *Notification) NewLessonNotifier() *LessonNotifier {
+	return &LessonNotifier{}
+}
+
+type LessonNotifier struct{}
+
+func (ln *LessonNotifier) SendNotification(ctx context.Context, user *model2.User) error {
+	return nil
+}
+
+func (ln *LessonNotifier) Close(ctx context.Context, stat *model2.StatNotifier) {
+}

--- a/backend/usecase/notification.go
+++ b/backend/usecase/notification.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 
+	"github.com/oinume/lekcije/backend/domain/repository"
 	"github.com/oinume/lekcije/backend/model2"
 )
 
@@ -13,7 +14,7 @@ func NewNotification() *Notification {
 	return &Notification{}
 }
 
-func (n *Notification) NewLessonNotifier() *LessonNotifier {
+func (n *Notification) NewLessonNotifier(lessonFetcher repository.LessonFetcher) *LessonNotifier {
 	return &LessonNotifier{}
 }
 

--- a/backend/usecase/user.go
+++ b/backend/usecase/user.go
@@ -114,6 +114,10 @@ func (u *User) FindByGoogleID(ctx context.Context, googleID string) (*model2.Use
 	return u.userRepo.FindByGoogleID(ctx, googleID)
 }
 
+func (u *User) FindAllByEmailVerified(ctx context.Context, notificationInterval int) ([]*model2.User, error) {
+	return u.userRepo.FindAllByEmailVerified(ctx, notificationInterval)
+}
+
 func (u *User) UpdateEmail(ctx context.Context, id uint, email string) error {
 	return u.userRepo.UpdateEmail(ctx, id, email)
 }


### PR DESCRIPTION
## WHAT
リファクタした lesson fetcherを infrastructure/dmm_eikaiwaに実装し、画面上からLessonFetcherを呼び出す処理は新しいものに置き換える。

## TODO
- [x] LessonFetcherのユニットテストが動くか？
  - [x] Test_lessonFetcher_parseHTML
  - [x] Test_lessonFetcher_Fetch_Concurrency
- [x] Notifierの実装(いったんコンパイルが通るところまででいいかも)
- [x] NewMockTransportの削除
- [x] [画面上からfetcherを使っている部分](https://github.com/oinume/lekcije/blob/443c9aaf52aabab689cb92556ceb599a85f0baa7/backend/usecase/following_teacher.go#L94)の置き換え
  - [x] 動作確認
  - [x] FetcherのDI
  - [x] u.mCountryRepo.FindAll(ctx)をDIする時に実行しておく
